### PR TITLE
feat(auth): Improve password hash entropy to resolve insufficient computational effort finding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,14 @@ NEXTAUTH_URL=http://localhost:3001
 # If .env.local also sets NEXTAUTH_SECRET, it overrides this value.
 NEXTAUTH_SECRET=replace-with-random-base64-secret
 
+# Server-side pepper used by PBKDF2-SHA256 to hash bearer tokens, API keys,
+# and OIDC refresh tokens before storage. Must be >=32 chars and kept stable
+# for the lifetime of the deployment — changing this value invalidates every
+# existing token_hash / key_hash row and requires re-issuing all credentials.
+# Generate once:
+#   openssl rand -base64 48
+AUTH_TOKEN_PEPPER=replace-with-random-base64-pepper
+
 # ---------- OAuth Providers (admin login) ----------
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/.env.vercel.template
+++ b/.env.vercel.template
@@ -20,6 +20,12 @@ NEXTAUTH_SECRET=<generate-with-openssl-rand-base64-32>
 # Generate with: openssl rand -base64 32
 # KEEP THIS SECRET! Do not commit to git.
 
+AUTH_TOKEN_PEPPER=<generate-with-openssl-rand-base64-48>
+# Server-side pepper for PBKDF2-SHA256 hashing of bearer tokens / API keys.
+# Generate with: openssl rand -base64 48
+# Must be >=32 chars. Rotating this invalidates every stored token_hash —
+# re-issue all bearer tokens and API keys after any rotation.
+
 # ========================================
 # REQUIRED - Signer Configuration
 # ========================================

--- a/scripts/bootstrap-admin.ts
+++ b/scripts/bootstrap-admin.ts
@@ -11,11 +11,12 @@
 import "./load-env-first";
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
-import { createHash, randomBytes } from "crypto";
+import { randomBytes } from "crypto";
 import { v4 as uuidv4 } from "uuid";
 import { eq } from "drizzle-orm";
 import * as schema from "../src/db/schema";
 import { users, sessions, signerConfig } from "../src/db/schema";
+import { hashToken } from "../src/lib/token-hash";
 
 async function main() {
   const databaseUrl = process.env.DATABASE_URL?.trim();
@@ -69,7 +70,7 @@ async function main() {
 
   const raw = randomBytes(32).toString("hex");
   const token = `pmth_${raw}`;
-  const hash = createHash("sha256").update(token).digest("hex");
+  const hash = hashToken(token);
   const sessionId = uuidv4();
   const expiresAt = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();
 

--- a/scripts/validate-env.js
+++ b/scripts/validate-env.js
@@ -23,6 +23,11 @@ const requiredVars = {
     example: "Run: openssl rand -base64 32",
     validate: (val) => val.length >= 32,
   },
+  AUTH_TOKEN_PEPPER: {
+    desc: "Server-side pepper for PBKDF2 token hashing (min 32 chars)",
+    example: "Run: openssl rand -base64 48",
+    validate: (val) => val.length >= 32,
+  },
   SIGNER_INTERNAL_URL: {
     desc: "URL of deployed go-livepeer signer",
     example: "https://your-signer.up.railway.app",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,71 +1,17 @@
 import { db } from "@/db/index";
 import { sessions, oidcClients, developerApps } from "@/db/schema";
 import { eq, and, gt } from "drizzle-orm";
-import {
-  createHash,
-  pbkdf2Sync,
-  randomBytes,
-  timingSafeEqual,
-} from "crypto";
+import { randomBytes } from "crypto";
 import { v4 as uuidv4 } from "uuid";
 import type { NextRequest } from "next/server";
 import { verifyAccessToken } from "@/lib/oidc/tokens";
 import { validateClientSecret } from "@/lib/oidc/clients";
+import { hashToken } from "@/lib/token-hash";
+
+export { hashToken };
 
 const TOKEN_PREFIX = "pmth_";
 const DEBUG_OIDC_LOGS = process.env.OIDC_DEBUG_LOGS === "1";
-const TOKEN_HASH_SCHEME = "pbkdf2_sha256";
-const TOKEN_HASH_ITERATIONS = 210000;
-const TOKEN_HASH_KEYLEN = 32;
-const TOKEN_HASH_DIGEST = "sha256";
-
-export function hashToken(token: string): string {
-  const salt = randomBytes(16).toString("hex");
-  const derivedKey = pbkdf2Sync(
-    token,
-    salt,
-    TOKEN_HASH_ITERATIONS,
-    TOKEN_HASH_KEYLEN,
-    TOKEN_HASH_DIGEST,
-  ).toString("hex");
-  return `${TOKEN_HASH_SCHEME}$${TOKEN_HASH_ITERATIONS}$${salt}$${derivedKey}`;
-}
-
-export function verifyTokenHash(token: string, storedHash: string): boolean {
-  const parts = storedHash.split("$");
-  if (parts.length === 4 && parts[0] === TOKEN_HASH_SCHEME) {
-    const iterations = Number(parts[1]);
-    const salt = parts[2];
-    const expected = parts[3];
-    if (!Number.isFinite(iterations) || iterations <= 0 || !salt || !expected) {
-      return false;
-    }
-
-    const actual = pbkdf2Sync(
-      token,
-      salt,
-      iterations,
-      TOKEN_HASH_KEYLEN,
-      TOKEN_HASH_DIGEST,
-    ).toString("hex");
-
-    const expectedBuf = Buffer.from(expected, "hex");
-    const actualBuf = Buffer.from(actual, "hex");
-    return (
-      expectedBuf.length === actualBuf.length &&
-      timingSafeEqual(expectedBuf, actualBuf)
-    );
-  }
-
-  // Backward compatibility for existing stored SHA-256 hashes.
-  const legacy = createHash("sha256").update(token).digest("hex");
-  const legacyExpectedBuf = Buffer.from(storedHash, "hex");
-  const legacyActualBuf = Buffer.from(legacy, "hex");
-  return (
-    legacyExpectedBuf.length === legacyActualBuf.length &&
-    timingSafeEqual(legacyExpectedBuf, legacyActualBuf)
-  );
-}
 
 export function generateBearerToken(): { token: string; hash: string } {
   const raw = randomBytes(32).toString("hex");

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,12 @@
 import { db } from "@/db/index";
 import { sessions, oidcClients, developerApps } from "@/db/schema";
 import { eq, and, gt } from "drizzle-orm";
-import { createHash, randomBytes } from "crypto";
+import {
+  createHash,
+  pbkdf2Sync,
+  randomBytes,
+  timingSafeEqual,
+} from "crypto";
 import { v4 as uuidv4 } from "uuid";
 import type { NextRequest } from "next/server";
 import { verifyAccessToken } from "@/lib/oidc/tokens";
@@ -9,9 +14,57 @@ import { validateClientSecret } from "@/lib/oidc/clients";
 
 const TOKEN_PREFIX = "pmth_";
 const DEBUG_OIDC_LOGS = process.env.OIDC_DEBUG_LOGS === "1";
+const TOKEN_HASH_SCHEME = "pbkdf2_sha256";
+const TOKEN_HASH_ITERATIONS = 210000;
+const TOKEN_HASH_KEYLEN = 32;
+const TOKEN_HASH_DIGEST = "sha256";
 
 export function hashToken(token: string): string {
-  return createHash("sha256").update(token).digest("hex");
+  const salt = randomBytes(16).toString("hex");
+  const derivedKey = pbkdf2Sync(
+    token,
+    salt,
+    TOKEN_HASH_ITERATIONS,
+    TOKEN_HASH_KEYLEN,
+    TOKEN_HASH_DIGEST,
+  ).toString("hex");
+  return `${TOKEN_HASH_SCHEME}$${TOKEN_HASH_ITERATIONS}$${salt}$${derivedKey}`;
+}
+
+export function verifyTokenHash(token: string, storedHash: string): boolean {
+  const parts = storedHash.split("$");
+  if (parts.length === 4 && parts[0] === TOKEN_HASH_SCHEME) {
+    const iterations = Number(parts[1]);
+    const salt = parts[2];
+    const expected = parts[3];
+    if (!Number.isFinite(iterations) || iterations <= 0 || !salt || !expected) {
+      return false;
+    }
+
+    const actual = pbkdf2Sync(
+      token,
+      salt,
+      iterations,
+      TOKEN_HASH_KEYLEN,
+      TOKEN_HASH_DIGEST,
+    ).toString("hex");
+
+    const expectedBuf = Buffer.from(expected, "hex");
+    const actualBuf = Buffer.from(actual, "hex");
+    return (
+      expectedBuf.length === actualBuf.length &&
+      timingSafeEqual(expectedBuf, actualBuf)
+    );
+  }
+
+  // Backward compatibility for existing stored SHA-256 hashes.
+  const legacy = createHash("sha256").update(token).digest("hex");
+  const legacyExpectedBuf = Buffer.from(storedHash, "hex");
+  const legacyActualBuf = Buffer.from(legacy, "hex");
+  return (
+    legacyExpectedBuf.length === legacyActualBuf.length &&
+    timingSafeEqual(legacyExpectedBuf, legacyActualBuf)
+  );
 }
 
 export function generateBearerToken(): { token: string; hash: string } {

--- a/src/lib/oidc/clients.ts
+++ b/src/lib/oidc/clients.ts
@@ -2,8 +2,9 @@ import { db } from "@/db/index";
 import { oidcClients } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
-import { createHash, randomBytes } from "crypto";
+import { randomBytes } from "crypto";
 import { DEFAULT_OIDC_SCOPES } from "@/lib/oidc/scopes";
+import { hashToken } from "@/lib/token-hash";
 
 export interface OidcClientConfig {
   clientId: string;
@@ -16,7 +17,7 @@ export interface OidcClientConfig {
 }
 
 export function hashClientSecret(secret: string): string {
-  return createHash("sha256").update(secret).digest("hex");
+  return hashToken(secret);
 }
 
 export async function registerClient(config: OidcClientConfig): Promise<void> {

--- a/src/lib/token-hash.ts
+++ b/src/lib/token-hash.ts
@@ -1,0 +1,61 @@
+/**
+ * Deterministic PBKDF2-SHA256 hashing for high-entropy credential material
+ * (bearer tokens, API keys, OIDC refresh tokens, admin invite codes).
+ *
+ * Why deterministic PBKDF2 and not per-record random salt:
+ *   These values are 256-bit random secrets, not user passwords. The hash
+ *   column is used as an indexed equality-lookup key (`WHERE token_hash = $1`),
+ *   so the KDF must map one plaintext to exactly one digest. We achieve
+ *   constant-time verification at the database level via the unique index,
+ *   and CWE-916 ("insufficient computational effort") is satisfied by the
+ *   OWASP-recommended PBKDF2 iteration count.
+ *
+ * Why a server-side pepper:
+ *   A global, deployment-scoped secret salt makes offline brute-force of
+ *   a stolen `token_hash` dump require also compromising the application
+ *   secret — the standard pepper pattern.
+ *
+ * Compatibility: digest is 64 hex chars, same shape as the previous
+ * `createHash("sha256")` output, so existing column types and unique
+ * indexes require no migration. Existing row values must be rotated
+ * manually (hard cutover, no SHA-256 fallback).
+ */
+
+import { pbkdf2Sync } from "crypto";
+
+const TOKEN_HASH_ITERATIONS = 600_000;
+const TOKEN_HASH_KEYLEN = 32;
+const TOKEN_HASH_DIGEST = "sha256";
+const MIN_PEPPER_LENGTH = 32;
+
+let cachedPepper: string | null = null;
+
+function loadPepper(): string {
+  if (cachedPepper !== null) return cachedPepper;
+
+  const pepper = process.env.AUTH_TOKEN_PEPPER?.trim();
+  if (!pepper || pepper.length < MIN_PEPPER_LENGTH) {
+    throw new Error(
+      `AUTH_TOKEN_PEPPER is required (min ${MIN_PEPPER_LENGTH} chars). ` +
+        `Generate one with: openssl rand -base64 48`,
+    );
+  }
+
+  cachedPepper = pepper;
+  return pepper;
+}
+
+/**
+ * Deterministic PBKDF2-SHA256 hash of a credential value, keyed by the
+ * server-side pepper. Returns a 64-character lowercase hex string suitable
+ * for direct equality comparison in the database.
+ */
+export function hashToken(token: string): string {
+  return pbkdf2Sync(
+    token,
+    loadPepper(),
+    TOKEN_HASH_ITERATIONS,
+    TOKEN_HASH_KEYLEN,
+    TOKEN_HASH_DIGEST,
+  ).toString("hex");
+}


### PR DESCRIPTION
Potential fix for [https://github.com/eliteprox/pymthouse/security/code-scanning/8](https://github.com/eliteprox/pymthouse/security/code-scanning/8)

Use a slow, salted KDF for newly generated token/API-key hashes, and keep backward compatibility for existing SHA-256 rows.

Best practical fix in the shown code:
- In `src/lib/auth.ts`, change `hashToken` from SHA-256 to PBKDF2 (Node built-in `crypto.pbkdf2Sync`) with:
  - random per-token salt
  - strong iteration count
  - fixed key length and digest
  - self-describing stored format (e.g. `pbkdf2_sha256$<iters>$<salt>$<hash>`).
- Also add a verifier helper that:
  - recognizes PBKDF2-formatted hashes and verifies with timing-safe compare;
  - falls back to legacy SHA-256 comparison for existing DB values to avoid breaking current sessions/API keys.
- No change is required in `src/app/api/v1/apps/[id]/keys/route.ts` because it already calls `hashToken`; after updating `hashToken`, all call sites automatically store stronger hashes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token and credential storage now uses PBKDF2-HMAC-SHA256 hashing with a server-side pepper.

* **Chores**
  * Consolidated token hashing logic across authentication modules.
  * New required environment variable `AUTH_TOKEN_PEPPER` must be configured (minimum 32 characters); changing it will invalidate stored token hashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->