### PR TITLE
fix(security): harden domain whitelist for scan alerts and simplify optional env checks

### DIFF
--- a/scripts/validate-env.js
+++ b/scripts/validate-env.js
@@ -41,14 +41,14 @@ const requiredVars = {
 };
 
 const optionalVars = {
-  GOOGLE_CLIENT_ID: "Google OAuth client ID (for admin login)",
-  GOOGLE_CLIENT_SECRET: "Google OAuth client secret",
-  GITHUB_CLIENT_ID: "GitHub OAuth client ID (for admin login)",
-  GITHUB_CLIENT_SECRET: "GitHub OAuth client secret",
-  NEXT_PUBLIC_PRIVY_APP_ID: "Privy app ID (for end-user wallets)",
-  PRIVY_APP_SECRET: "Privy app secret",
-  NAAP_METRICS_URL: "NaaP metrics endpoint (optional)",
-  SIGNER_CLI_URL: "Signer CLI URL (defaults to SIGNER_INTERNAL_URL)",
+  GOOGLE_CLIENT_ID: "",
+  GOOGLE_CLIENT_SECRET: "",
+  GITHUB_CLIENT_ID: "",
+  GITHUB_CLIENT_SECRET: "",
+  NEXT_PUBLIC_PRIVY_APP_ID: "",
+  PRIVY_APP_SECRET: "",
+  NAAP_METRICS_URL: "",
+  SIGNER_CLI_URL: "",
 };
 
 console.log("🔍 Validating environment configuration for Vercel deployment...\n");
@@ -86,7 +86,7 @@ console.log("\n📋 Optional Variables:");
 let hasOAuth = false;
 let hasPrivy = false;
 
-for (const [key, desc] of Object.entries(optionalVars)) {
+for (const key of Object.keys(optionalVars)) {
   const value = process.env[key];
   
   if (value) {

--- a/src/lib/domain-whitelist.ts
+++ b/src/lib/domain-whitelist.ts
@@ -25,6 +25,13 @@ type NormalizeResult = NormalizationResult | NormalizationError;
 const DEFAULT_HTTP_PORT = 80;
 const DEFAULT_HTTPS_PORT = 443;
 
+// Cap attacker-controlled input length before any pattern matching to eliminate
+// ReDoS / polynomial-regex surface (OWASP ReDoS guidance, CWE-1333).
+// A legitimate origin is scheme (8) + host (max 253 per RFC 1035) + port (6) +
+// brackets/colons, so 512 is a generous upper bound.
+const MAX_INPUT_LENGTH = 512;
+const SLASH_CHAR_CODE = 47;
+
 function isLocalhost(host: string): boolean {
   const h = host.toLowerCase();
   return h === "localhost" || h === "127.0.0.1" || h === "::1" || h === "[::1]";
@@ -35,14 +42,32 @@ function getDefaultPort(scheme: string): number {
 }
 
 export function normalizeDomainWhitelist(input: string): NormalizeResult {
+  if (typeof input !== "string") {
+    return { success: false, error: "Domain must be a string" };
+  }
+
+  // Reject oversize input before running any regex-based parsing so that
+  // attacker-controlled strings cannot trigger super-linear backtracking.
+  if (input.length > MAX_INPUT_LENGTH) {
+    return { success: false, error: `Domain exceeds max length of ${MAX_INPUT_LENGTH} characters` };
+  }
+
   let trimmed = input.trim();
 
   if (!trimmed) {
     return { success: false, error: "Domain cannot be empty" };
   }
 
-  // Remove trailing slashes for bare host input like "example.com///"
-  trimmed = trimmed.replace(/\/+$/, "");
+  // Strip trailing slashes without a regex (e.g. "example.com///").
+  // Using a bounded index scan guarantees O(n) worst case and avoids the
+  // polynomial-regex ReDoS surface flagged by CodeQL (js/polynomial-redos).
+  let end = trimmed.length;
+  while (end > 0 && trimmed.charCodeAt(end - 1) === SLASH_CHAR_CODE) {
+    end--;
+  }
+  if (end !== trimmed.length) {
+    trimmed = trimmed.slice(0, end);
+  }
 
   // Parse scheme and host:port
   let scheme: string | null = null;

--- a/src/lib/domain-whitelist.ts
+++ b/src/lib/domain-whitelist.ts
@@ -46,13 +46,13 @@ export function normalizeDomainWhitelist(input: string): NormalizeResult {
     return { success: false, error: "Domain must be a string" };
   }
 
+  let trimmed = input.trim();
+
   // Reject oversize input before running any regex-based parsing so that
   // attacker-controlled strings cannot trigger super-linear backtracking.
-  if (input.length > MAX_INPUT_LENGTH) {
+  if (trimmed.length > MAX_INPUT_LENGTH) {
     return { success: false, error: `Domain exceeds max length of ${MAX_INPUT_LENGTH} characters` };
   }
-
-  let trimmed = input.trim();
 
   if (!trimmed) {
     return { success: false, error: "Domain cannot be empty" };


### PR DESCRIPTION
### Summary

This branch closes gaps flagged by static analysis around **regex safety** and keeps the deployment env checker easier to maintain.

- **`src/lib/domain-whitelist.ts`**: Reject overlong input before any regex work, and strip trailing slashes with a bounded scan instead of a regex loop that could surface **polynomial ReDoS** (`js/polynomial-redos` / CWE-1333). Comments in the module document the rationale and limits.
- **`scripts/validate-env.js`**: Treat optional variables as a simple key list (empty-string placeholders) so iteration stays straightforward without extra per-key metadata.

### Context

Changes are aimed at **CodeQL / security scanning** expectations for attacker-controlled strings and redundant optional-variable structure, without changing product behavior for valid origins or required env validation.

### Test plan

- [ ] Run `node scripts/validate-env.js` with representative env (required set, optional unset/partial).
- [ ] Exercise code paths that call `normalizeDomainWhitelist` with normal origins, localhost `http`, IPv6 forms, trailing slashes, and an input longer than the documented cap to confirm fast rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened domain whitelist validation: rejects non-string or excessively long entries and more reliably normalizes input to prevent invalid domains.

* **Chores**
  * Simplified handling of optional environment variables by standardizing placeholders and tightening iteration logic for more predictable configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->