### PR TITLE
feat(apps): draft app deletion, revert-to-draft, and OIDC cleanup

### DIFF
--- a/src/app/api/v1/apps/[id]/revert-draft/route.ts
+++ b/src/app/api/v1/apps/[id]/revert-draft/route.ts
@@ -1,0 +1,62 @@
+/**
+ * Withdraw from review — transition from submitted back to draft (owner only).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/next-auth-options";
+import { db } from "@/db/index";
+import { developerApps } from "@/db/schema";
+import { and, eq } from "drizzle-orm";
+import { getProviderApp } from "@/lib/provider-apps";
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = (session.user as Record<string, unknown>).id as string;
+  const { id: clientId } = await params;
+  const app = await getProviderApp(clientId);
+  if (!app) {
+    return NextResponse.json({ error: "App not found" }, { status: 404 });
+  }
+
+  if (app.ownerId !== userId) {
+    return NextResponse.json(
+      { error: "Only the app owner can revert a submitted app to draft" },
+      { status: 403 },
+    );
+  }
+
+  const now = new Date().toISOString();
+  const updated = await db
+    .update(developerApps)
+    .set({
+      status: "draft",
+      submittedAt: null,
+      updatedAt: now,
+    })
+    .where(and(eq(developerApps.id, app.id), eq(developerApps.status, "submitted")))
+    .returning({ id: developerApps.id });
+
+  if (updated.length === 0) {
+    return NextResponse.json(
+      {
+        error: "Invalid status",
+        message: `App is currently ${app.status}. Only submitted apps can be reverted to draft.`,
+      },
+      { status: 409 },
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    status: "draft",
+    message: "App reverted to draft",
+  });
+}

--- a/src/app/api/v1/apps/[id]/route.ts
+++ b/src/app/api/v1/apps/[id]/route.ts
@@ -11,6 +11,7 @@ import {
   getAuthorizedProviderApp,
   appEditForbiddenResponse,
 } from "@/lib/provider-apps";
+import { deleteDeveloperAppAndRelatedData } from "@/lib/delete-developer-app";
 
 export async function GET(
   _request: NextRequest,
@@ -143,4 +144,33 @@ export async function PUT(
   }
 
   return NextResponse.json({ success: true });
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: clientId } = await params;
+  const auth = await getAuthorizedProviderApp(clientId);
+  if (!auth) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (auth.app.ownerId !== auth.userId) {
+    return NextResponse.json(
+      { error: "Only the app owner can delete this app." },
+      { status: 403 },
+    );
+  }
+
+  if (auth.app.status !== "draft") {
+    return NextResponse.json(
+      { error: "Only draft apps can be deleted." },
+      { status: 400 },
+    );
+  }
+
+  await deleteDeveloperAppAndRelatedData(auth.app.id, auth.app.oidcClientId ?? null);
+
+  return new NextResponse(null, { status: 204 });
 }

--- a/src/app/apps/[id]/page.tsx
+++ b/src/app/apps/[id]/page.tsx
@@ -88,6 +88,17 @@ export default function AppDetailPage() {
     );
   }, []);
 
+  const handleRevertedToDraft = useCallback(() => {
+    setAppData((prev) =>
+      prev
+        ? {
+            ...prev,
+            state: { ...prev.state, status: "draft" },
+          }
+        : null,
+    );
+  }, []);
+
   if (loading) {
     return (
       <DashboardLayout>
@@ -160,6 +171,7 @@ export default function AppDetailPage() {
         canEdit={appData.canEdit}
         canSubmitForReview={appData.canSubmitForReview}
         onReviewSubmitted={handleReviewSubmitted}
+        onRevertedToDraft={handleRevertedToDraft}
       />
     </DashboardLayout>
   );

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
 import AppInfoStep from "./steps/AppInfoStep";
 import AppModeStep from "./steps/AppModeStep";
 import TestingStep from "./steps/TestingStep";
@@ -24,6 +25,8 @@ interface Props {
   canSubmitForReview?: boolean;
   /** Called after a successful submit so the parent can refresh status UI. */
   onReviewSubmitted?: () => void;
+  /** Called after reverting from submitted to draft (header badge, etc.). */
+  onRevertedToDraft?: () => void;
 }
 
 function mergeFormData(initial: Partial<AppFormData>): AppFormData {
@@ -49,7 +52,9 @@ export default function AppSettingsScreen({
   canEdit = true,
   canSubmitForReview = false,
   onReviewSubmitted,
+  onRevertedToDraft,
 }: Props) {
+  const router = useRouter();
   const [formData, setFormData] = useState<AppFormData>(() =>
     mergeFormData(initialData),
   );
@@ -68,6 +73,8 @@ export default function AppSettingsScreen({
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [submittingForReview, setSubmittingForReview] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [reverting, setReverting] = useState(false);
 
   const updateFormData = useCallback(
     (updates: Partial<AppFormData>) => {
@@ -154,6 +161,74 @@ export default function AppSettingsScreen({
     }
   }, [appId, canSubmitForReview, onReviewSubmitted]);
 
+  const deleteDraftApp = useCallback(async () => {
+    if (!canSubmitForReview || appState.status !== "draft") return;
+    if (
+      !confirm(
+        `Delete "${formData.name.trim() || "this app"}"? This permanently removes the draft app and cannot be undone.`,
+      )
+    ) {
+      return;
+    }
+    setDeleting(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const res = await fetch(`/api/v1/apps/${appId}`, { method: "DELETE" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(
+          typeof body.error === "string"
+            ? body.error
+            : `Delete failed (${res.status})`,
+        );
+      }
+      router.push("/apps");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setDeleting(false);
+    }
+  }, [appId, appState.status, canSubmitForReview, formData.name, router]);
+
+  const revertToDraft = useCallback(async () => {
+    if (!canSubmitForReview || appState.status !== "submitted") return;
+    if (
+      !confirm(
+        "Revert this app to draft? It will leave the review queue until you submit again.",
+      )
+    ) {
+      return;
+    }
+    setReverting(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const res = await fetch(`/api/v1/apps/${appId}/revert-draft`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        let msg = `Revert failed (${res.status})`;
+        try {
+          const data = text ? JSON.parse(text) : {};
+          if (data.message) msg = data.message;
+          else if (data.error) msg = data.error;
+        } catch {
+          /* keep generic */
+        }
+        throw new Error(msg);
+      }
+      setAppState((s) => ({ ...s, status: "draft" }));
+      onRevertedToDraft?.();
+      setMessage("App is back in draft. You can edit and submit again when ready.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Revert failed");
+    } finally {
+      setReverting(false);
+    }
+  }, [appId, appState.status, canSubmitForReview, onRevertedToDraft]);
+
   const addPostLogoutUri = () => {
     const trimmed = newPostLogoutUri.trim();
     if (!trimmed || postLogoutRedirectUris.includes(trimmed)) return;
@@ -203,6 +278,29 @@ export default function AppSettingsScreen({
               className="px-4 py-2 text-sm font-medium rounded-lg bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               {submittingForReview ? "Submitting…" : "Submit for review"}
+            </button>
+          </div>
+        )}
+      {canEdit &&
+        canSubmitForReview &&
+        appState.status === "submitted" && (
+          <div className="p-4 rounded-xl border border-amber-500/25 bg-amber-500/5 space-y-3">
+            <div>
+              <h2 className="text-sm font-semibold text-zinc-100">
+                Revert to draft
+              </h2>
+              <p className="text-sm text-zinc-400 mt-1">
+                This app is waiting for administrator review. You can withdraw it
+                from the queue to make changes, then submit again.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => void revertToDraft()}
+              disabled={reverting}
+              className="px-4 py-2 text-sm font-medium rounded-lg border border-amber-500/40 text-amber-200 hover:bg-amber-500/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {reverting ? "Reverting…" : "Revert to draft"}
             </button>
           </div>
         )}
@@ -331,6 +429,24 @@ export default function AppSettingsScreen({
         <EndpointField label="Authorize" value={authorizeUrl} />
         <EndpointField label="Token" value={tokenUrl} />
       </section>
+
+      {canSubmitForReview && appState.status === "draft" && (
+        <section className="rounded-xl border border-red-500/25 bg-red-500/5 p-6 space-y-3">
+          <h2 className="text-sm font-semibold text-zinc-100">Delete draft app</h2>
+          <p className="text-sm text-zinc-400">
+            Permanently remove this app, its OIDC client, and related data. This
+            cannot be undone.
+          </p>
+          <button
+            type="button"
+            onClick={() => void deleteDraftApp()}
+            disabled={deleting}
+            className="px-4 py-2 text-sm font-medium rounded-lg border border-red-500/40 text-red-300 hover:bg-red-500/15 disabled:opacity-50 disabled:cursor-not-allowed transition-colors w-fit"
+          >
+            {deleting ? "Deleting…" : "Delete app"}
+          </button>
+        </section>
+      )}
 
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 pt-2 border-t border-zinc-800">
         <p className="text-xs text-zinc-500 max-w-xl">

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -167,59 +167,6 @@ export const oidcClients = pgTable("oidc_clients", {
     .$defaultFn(() => new Date().toISOString()),
 });
 
-// Authorization codes (short-lived, one-time use)
-export const oidcAuthCodes = pgTable("oidc_auth_codes", {
-  id: text("id").primaryKey(),
-  code: text("code").notNull().unique(),
-  clientId: text("client_id").notNull(),
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id),
-  scopes: text("scopes").notNull(),
-  nonce: text("nonce"),
-  codeChallenge: text("code_challenge"),
-  codeChallengeMethod: text("code_challenge_method"), // S256 | plain
-  redirectUri: text("redirect_uri").notNull(),
-  expiresAt: text("expires_at").notNull(),
-  consumedAt: text("consumed_at"),
-  createdAt: text("created_at")
-    .notNull()
-    .$defaultFn(() => new Date().toISOString()),
-});
-
-// Refresh tokens for token renewal
-export const oidcRefreshTokens = pgTable("oidc_refresh_tokens", {
-  id: text("id").primaryKey(),
-  tokenHash: text("token_hash").notNull().unique(),
-  clientId: text("client_id").notNull(),
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id),
-  scopes: text("scopes").notNull(),
-  expiresAt: text("expires_at").notNull(),
-  revokedAt: text("revoked_at"),
-  createdAt: text("created_at")
-    .notNull()
-    .$defaultFn(() => new Date().toISOString()),
-});
-
-// Device authorization codes (RFC 8628)
-export const oidcDeviceCodes = pgTable("oidc_device_codes", {
-  id: text("id").primaryKey(),
-  deviceCode: text("device_code").notNull().unique(),
-  userCode: text("user_code").notNull().unique(),
-  clientId: text("client_id").notNull(),
-  scopes: text("scopes").notNull(),
-  verificationUri: text("verification_uri").notNull(),
-  expiresAt: text("expires_at").notNull(),
-  interval: integer("interval").notNull().default(5), // polling interval in seconds
-  status: text("status").notNull().default("pending"), // pending | authorized | denied | expired
-  userId: text("user_id").references(() => users.id), // set when user authorizes
-  createdAt: text("created_at")
-    .notNull()
-    .$defaultFn(() => new Date().toISOString()),
-});
-
 // ============================================
 // Developer App Tables
 // ============================================
@@ -494,9 +441,6 @@ export type StreamSession = typeof streamSessions.$inferSelect;
 export type Transaction = typeof transactions.$inferSelect;
 export type OidcSigningKey = typeof oidcSigningKeys.$inferSelect;
 export type OidcClient = typeof oidcClients.$inferSelect;
-export type OidcAuthCode = typeof oidcAuthCodes.$inferSelect;
-export type OidcRefreshToken = typeof oidcRefreshTokens.$inferSelect;
-export type OidcDeviceCode = typeof oidcDeviceCodes.$inferSelect;
 export type DeveloperApp = typeof developerApps.$inferSelect;
 export type NewDeveloperApp = typeof developerApps.$inferInsert;
 export type AdminInvite = typeof adminInvites.$inferSelect;

--- a/src/lib/delete-developer-app.ts
+++ b/src/lib/delete-developer-app.ts
@@ -6,10 +6,8 @@ import {
   authAuditLog,
   developerApps,
   endUsers,
-  oidcAuthCodes,
   oidcClients,
-  oidcDeviceCodes,
-  oidcRefreshTokens,
+  oidcPayloads,
   planCapabilityBundles,
   plans,
   providerAdmins,
@@ -20,7 +18,7 @@ import {
   transactions,
   usageRecords,
 } from "@/db/schema";
-import { eq, inArray, or } from "drizzle-orm";
+import { eq, inArray, or, sql } from "drizzle-orm";
 
 /**
  * Permanently removes a developer app row and dependent records.
@@ -30,13 +28,22 @@ export async function deleteDeveloperAppAndRelatedData(
   appInternalId: string,
   oidcClientPk: string | null,
 ): Promise<void> {
-  const oauthClientIdInternal = oidcClientPk;
-
   await db.transaction(async (tx) => {
-    if (oauthClientIdInternal) {
-      await tx.delete(oidcAuthCodes).where(eq(oidcAuthCodes.clientId, oauthClientIdInternal));
-      await tx.delete(oidcRefreshTokens).where(eq(oidcRefreshTokens.clientId, oauthClientIdInternal));
-      await tx.delete(oidcDeviceCodes).where(eq(oidcDeviceCodes.clientId, oauthClientIdInternal));
+    if (oidcClientPk) {
+      const clientRows = await tx
+        .select({ clientId: oidcClients.clientId })
+        .from(oidcClients)
+        .where(eq(oidcClients.id, oidcClientPk))
+        .limit(1);
+      const oauthClientId = clientRows[0]?.clientId;
+      if (oauthClientId) {
+        await tx.delete(oidcPayloads).where(
+          or(
+            sql`(${oidcPayloads.payload})::jsonb->>'clientId' = ${oauthClientId}`,
+            sql`(${oidcPayloads.payload})::jsonb->>'client_id' = ${oauthClientId}`,
+          ),
+        );
+      }
     }
 
     await tx.delete(apiKeys).where(eq(apiKeys.clientId, appInternalId));

--- a/src/lib/delete-developer-app.ts
+++ b/src/lib/delete-developer-app.ts
@@ -30,12 +30,14 @@ export async function deleteDeveloperAppAndRelatedData(
   appInternalId: string,
   oidcClientPk: string | null,
 ): Promise<void> {
-  const oauthClientIdPublic = appInternalId;
+  const oauthClientIdInternal = oidcClientPk;
 
   await db.transaction(async (tx) => {
-    await tx.delete(oidcAuthCodes).where(eq(oidcAuthCodes.clientId, oauthClientIdPublic));
-    await tx.delete(oidcRefreshTokens).where(eq(oidcRefreshTokens.clientId, oauthClientIdPublic));
-    await tx.delete(oidcDeviceCodes).where(eq(oidcDeviceCodes.clientId, oauthClientIdPublic));
+    if (oauthClientIdInternal) {
+      await tx.delete(oidcAuthCodes).where(eq(oidcAuthCodes.clientId, oauthClientIdInternal));
+      await tx.delete(oidcRefreshTokens).where(eq(oidcRefreshTokens.clientId, oauthClientIdInternal));
+      await tx.delete(oidcDeviceCodes).where(eq(oidcDeviceCodes.clientId, oauthClientIdInternal));
+    }
 
     await tx.delete(apiKeys).where(eq(apiKeys.clientId, appInternalId));
     await tx.delete(subscriptions).where(eq(subscriptions.clientId, appInternalId));

--- a/src/lib/delete-developer-app.ts
+++ b/src/lib/delete-developer-app.ts
@@ -1,0 +1,89 @@
+import { db } from "@/db/index";
+import {
+  apiKeys,
+  appAllowedDomains,
+  appUsers,
+  authAuditLog,
+  developerApps,
+  endUsers,
+  oidcAuthCodes,
+  oidcClients,
+  oidcDeviceCodes,
+  oidcRefreshTokens,
+  planCapabilityBundles,
+  plans,
+  providerAdmins,
+  sessions,
+  signerConfig,
+  streamSessions,
+  subscriptions,
+  transactions,
+  usageRecords,
+} from "@/db/schema";
+import { eq, inArray, or } from "drizzle-orm";
+
+/**
+ * Permanently removes a developer app row and dependent records.
+ * Caller must enforce authorization (e.g. owner-only, draft-only).
+ */
+export async function deleteDeveloperAppAndRelatedData(
+  appInternalId: string,
+  oidcClientPk: string | null,
+): Promise<void> {
+  const oauthClientIdPublic = appInternalId;
+
+  await db.transaction(async (tx) => {
+    await tx.delete(oidcAuthCodes).where(eq(oidcAuthCodes.clientId, oauthClientIdPublic));
+    await tx.delete(oidcRefreshTokens).where(eq(oidcRefreshTokens.clientId, oauthClientIdPublic));
+    await tx.delete(oidcDeviceCodes).where(eq(oidcDeviceCodes.clientId, oauthClientIdPublic));
+
+    await tx.delete(apiKeys).where(eq(apiKeys.clientId, appInternalId));
+    await tx.delete(subscriptions).where(eq(subscriptions.clientId, appInternalId));
+    await tx.delete(planCapabilityBundles).where(eq(planCapabilityBundles.clientId, appInternalId));
+    await tx.delete(plans).where(eq(plans.clientId, appInternalId));
+
+    await tx.delete(usageRecords).where(eq(usageRecords.clientId, appInternalId));
+    await tx.delete(authAuditLog).where(eq(authAuditLog.clientId, appInternalId));
+    await tx.delete(appAllowedDomains).where(eq(appAllowedDomains.appId, appInternalId));
+    await tx.delete(appUsers).where(eq(appUsers.clientId, appInternalId));
+    await tx.delete(providerAdmins).where(eq(providerAdmins.clientId, appInternalId));
+
+    const endUserRows = await tx
+      .select({ id: endUsers.id })
+      .from(endUsers)
+      .where(eq(endUsers.appId, appInternalId));
+    const endUserIds = endUserRows.map((row) => row.id);
+
+    const streamSessionCond =
+      endUserIds.length > 0
+        ? or(eq(streamSessions.appId, appInternalId), inArray(streamSessions.endUserId, endUserIds))
+        : eq(streamSessions.appId, appInternalId);
+
+    const sessionIdRows = await tx
+      .select({ id: streamSessions.id })
+      .from(streamSessions)
+      .where(streamSessionCond);
+    const streamSessionIds = sessionIdRows.map((row) => row.id);
+    if (streamSessionIds.length > 0) {
+      await tx.delete(transactions).where(inArray(transactions.streamSessionId, streamSessionIds));
+    }
+    await tx.delete(streamSessions).where(streamSessionCond);
+
+    await tx.delete(transactions).where(eq(transactions.clientId, appInternalId));
+    await tx.delete(transactions).where(eq(transactions.appId, appInternalId));
+    if (endUserIds.length > 0) {
+      await tx.delete(transactions).where(inArray(transactions.endUserId, endUserIds));
+    }
+
+    await tx.delete(endUsers).where(eq(endUsers.appId, appInternalId));
+
+    await tx.delete(sessions).where(eq(sessions.appId, appInternalId));
+    await tx.delete(signerConfig).where(eq(signerConfig.clientId, appInternalId));
+
+    await tx.delete(developerApps).where(eq(developerApps.id, appInternalId));
+
+    if (oidcClientPk) {
+      await tx.delete(oidcClients).where(eq(oidcClients.id, oidcClientPk));
+    }
+  });
+}


### PR DESCRIPTION
This change adds owner-facing app lifecycle actions for drafts and submitted listings, backed by new API routes and a shared deletion helper.

**API**

- **DELETE** `/api/v1/apps/[id]` — Permanently deletes a developer app and related data when the caller is allowed to (e.g. draft-only, per existing auth rules).
- **POST** `/api/v1/apps/[id]/revert-draft` — Lets an owner move a submitted app back to draft when permitted.

**Client**

- **App settings / detail** — UI to delete draft apps and revert submitted apps to draft, with confirmations and state updates (`AppSettingsScreen`, app detail page).

**Data layer**

- **`deleteDeveloperAppAndRelatedData`** — Centralizes cascading deletes for the app and dependents. OIDC auth-code, refresh-token, and device-code rows are removed using the internal OIDC client primary key when present; the `oidc_clients` row delete stays conditional on that key, so behavior stays correct when no OIDC client exists.

**Suggested review focus**

- Authorization: only the right roles/states can delete or revert.
- Transaction ordering and FK coverage in `delete-developer-app.ts`, especially OIDC token cleanup vs `developerApps` / `oidcClients` removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can revert submitted apps back to draft for further editing; UI shows a “Revert to draft” action with confirmation and success feedback.
  * Users can permanently delete draft apps; UI shows a “Delete draft app” action with confirmation, progress state, and redirect on success.
  * Deleting an app performs comprehensive cleanup so related configurations and data are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->