### PR TITLE
feat: signer/usage integration tests, usage route Basic-auth fix, and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: pymthouse_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d pymthouse_test"
+          --health-interval 4s
+          --health-timeout 5s
+          --health-retries 15
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/pymthouse_test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply database migrations
+        run: npm run db:prepare
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,15 @@ jobs:
           node-version: "22"
           cache: npm
 
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+          key: cache-node-modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            cache-node-modules-${{ runner.os }}-
+
       - name: Install dependencies
         run: npm ci
 
@@ -52,3 +61,13 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 7
+   
+     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
 
     env:
       DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/pymthouse_test
+      AUTH_TOKEN_PEPPER: ci-test-auth-token-pepper-value-please-change
+      NEXTAUTH_SECRET: ci-test-nextauth-secret-please-change
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,5 @@ next-env.d.ts
 *.db-wal
 *.db-shm
 
-# drizzle
-/drizzle/
-
 # proto generated
 src/lib/proto-generated.*

--- a/drizzle/0000_init_pg.sql
+++ b/drizzle/0000_init_pg.sql
@@ -1,0 +1,377 @@
+CREATE TABLE "admin_invites" (
+	"id" text PRIMARY KEY NOT NULL,
+	"code" text NOT NULL,
+	"created_by" text NOT NULL,
+	"used_by" text,
+	"expires_at" text NOT NULL,
+	"created_at" text NOT NULL,
+	CONSTRAINT "admin_invites_code_unique" UNIQUE("code")
+);
+--> statement-breakpoint
+CREATE TABLE "api_keys" (
+	"id" text PRIMARY KEY NOT NULL,
+	"key_hash" text NOT NULL,
+	"user_id" text,
+	"client_id" text NOT NULL,
+	"subscription_id" text,
+	"label" text,
+	"status" text DEFAULT 'active' NOT NULL,
+	"created_at" text NOT NULL,
+	"revoked_at" text,
+	CONSTRAINT "api_keys_key_hash_unique" UNIQUE("key_hash")
+);
+--> statement-breakpoint
+CREATE TABLE "app_allowed_domains" (
+	"id" text PRIMARY KEY NOT NULL,
+	"app_id" text NOT NULL,
+	"domain" text NOT NULL,
+	"verified" integer DEFAULT 0 NOT NULL,
+	"purpose" text DEFAULT 'cors' NOT NULL,
+	"verification_token" text,
+	"verified_at" text,
+	"created_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "app_allowed_domains_app_id_domain_unique" ON "app_allowed_domains" ("app_id","domain");
+--> statement-breakpoint
+CREATE TABLE "app_users" (
+	"id" text PRIMARY KEY NOT NULL,
+	"client_id" text NOT NULL,
+	"external_user_id" text NOT NULL,
+	"email" text,
+	"status" text DEFAULT 'active' NOT NULL,
+	"role" text DEFAULT 'user' NOT NULL,
+	"created_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "auth_audit_log" (
+	"id" text PRIMARY KEY NOT NULL,
+	"client_id" text,
+	"actor_user_id" text,
+	"action" text NOT NULL,
+	"status" text NOT NULL,
+	"correlation_id" text NOT NULL,
+	"metadata" text,
+	"created_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "developer_apps" (
+	"id" text PRIMARY KEY NOT NULL,
+	"owner_id" text NOT NULL,
+	"oidc_client_id" text,
+	"name" text NOT NULL,
+	"subtitle" text,
+	"description" text,
+	"category" text,
+	"logo_light_url" text,
+	"logo_dark_url" text,
+	"developer_name" text,
+	"website_url" text,
+	"support_url" text,
+	"privacy_policy_url" text,
+	"tos_url" text,
+	"demo_recording_url" text,
+	"links_to_purchases" integer DEFAULT 0 NOT NULL,
+	"status" text DEFAULT 'draft' NOT NULL,
+	"reviewer_notes" text,
+	"reviewed_by" text,
+	"reviewed_at" text,
+	"submitted_at" text,
+	"pending_scopes" text,
+	"pending_grant_types" text,
+	"pending_revision_submitted_at" text,
+	"branding_mode" text DEFAULT 'blackLabel' NOT NULL,
+	"custom_login_enabled" integer DEFAULT 0 NOT NULL,
+	"custom_login_domain" text,
+	"custom_domain_verified_at" text,
+	"custom_domain_verification_token" text,
+	"custom_issuer_enabled" integer DEFAULT 0 NOT NULL,
+	"custom_issuer_url" text,
+	"branding_primary_color" text,
+	"branding_logo_url" text,
+	"branding_support_email" text,
+	"billing_pattern" text DEFAULT 'app_level' NOT NULL,
+	"jwks_uri" text,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL,
+	"published_at" text
+);
+--> statement-breakpoint
+CREATE TABLE "end_users" (
+	"id" text PRIMARY KEY NOT NULL,
+	"app_id" text,
+	"external_user_id" text,
+	"name" text,
+	"email" text,
+	"privy_did" text,
+	"wallet_address" text,
+	"credit_balance_wei" text DEFAULT '0' NOT NULL,
+	"is_active" integer DEFAULT 1 NOT NULL,
+	"created_at" text NOT NULL,
+	CONSTRAINT "end_users_privy_did_unique" UNIQUE("privy_did")
+);
+--> statement-breakpoint
+CREATE TABLE "oidc_auth_codes" (
+	"id" text PRIMARY KEY NOT NULL,
+	"code" text NOT NULL,
+	"client_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"scopes" text NOT NULL,
+	"nonce" text,
+	"code_challenge" text,
+	"code_challenge_method" text,
+	"redirect_uri" text NOT NULL,
+	"expires_at" text NOT NULL,
+	"consumed_at" text,
+	"created_at" text NOT NULL,
+	CONSTRAINT "oidc_auth_codes_code_unique" UNIQUE("code")
+);
+--> statement-breakpoint
+CREATE TABLE "oidc_clients" (
+	"id" text PRIMARY KEY NOT NULL,
+	"client_id" text NOT NULL,
+	"client_secret_hash" text,
+	"display_name" text NOT NULL,
+	"redirect_uris" text NOT NULL,
+	"allowed_scopes" text DEFAULT 'openid profile email' NOT NULL,
+	"grant_types" text DEFAULT 'authorization_code,refresh_token' NOT NULL,
+	"token_endpoint_auth_method" text DEFAULT 'none' NOT NULL,
+	"post_logout_redirect_uris" text,
+	"initiate_login_uri" text,
+	"logo_uri" text,
+	"policy_uri" text,
+	"tos_uri" text,
+	"client_uri" text,
+	"created_at" text NOT NULL,
+	CONSTRAINT "oidc_clients_client_id_unique" UNIQUE("client_id")
+);
+--> statement-breakpoint
+CREATE TABLE "oidc_device_codes" (
+	"id" text PRIMARY KEY NOT NULL,
+	"device_code" text NOT NULL,
+	"user_code" text NOT NULL,
+	"client_id" text NOT NULL,
+	"scopes" text NOT NULL,
+	"verification_uri" text NOT NULL,
+	"expires_at" text NOT NULL,
+	"interval" integer DEFAULT 5 NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"user_id" text,
+	"created_at" text NOT NULL,
+	CONSTRAINT "oidc_device_codes_device_code_unique" UNIQUE("device_code"),
+	CONSTRAINT "oidc_device_codes_user_code_unique" UNIQUE("user_code")
+);
+--> statement-breakpoint
+CREATE TABLE "oidc_payloads" (
+	"id" text NOT NULL,
+	"model" text NOT NULL,
+	"payload" text NOT NULL,
+	"expires_at" integer,
+	"consumed_at" integer,
+	"uid" text,
+	"user_code" text,
+	"grant_id" text,
+	CONSTRAINT "oidc_payloads_id_model_pk" PRIMARY KEY("id","model")
+);
+--> statement-breakpoint
+CREATE TABLE "oidc_refresh_tokens" (
+	"id" text PRIMARY KEY NOT NULL,
+	"token_hash" text NOT NULL,
+	"client_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"scopes" text NOT NULL,
+	"expires_at" text NOT NULL,
+	"revoked_at" text,
+	"created_at" text NOT NULL,
+	CONSTRAINT "oidc_refresh_tokens_token_hash_unique" UNIQUE("token_hash")
+);
+--> statement-breakpoint
+CREATE TABLE "oidc_signing_keys" (
+	"id" text PRIMARY KEY NOT NULL,
+	"kid" text NOT NULL,
+	"algorithm" text DEFAULT 'RS256' NOT NULL,
+	"public_key_pem" text NOT NULL,
+	"private_key_pem" text NOT NULL,
+	"active" integer DEFAULT 1 NOT NULL,
+	"created_at" text NOT NULL,
+	"rotated_at" text,
+	CONSTRAINT "oidc_signing_keys_kid_unique" UNIQUE("kid")
+);
+--> statement-breakpoint
+CREATE TABLE "plan_capability_bundles" (
+	"id" text PRIMARY KEY NOT NULL,
+	"plan_id" text NOT NULL,
+	"client_id" text NOT NULL,
+	"pipeline" text NOT NULL,
+	"model_id" text NOT NULL,
+	"sla_target_score" real,
+	"sla_target_p95_ms" integer,
+	"max_price_per_unit" text,
+	"created_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "plans" (
+	"id" text PRIMARY KEY NOT NULL,
+	"client_id" text NOT NULL,
+	"name" text NOT NULL,
+	"type" text DEFAULT 'free' NOT NULL,
+	"price_amount" text DEFAULT '0' NOT NULL,
+	"price_currency" text DEFAULT 'USD' NOT NULL,
+	"status" text DEFAULT 'draft' NOT NULL,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "provider_admins" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"client_id" text NOT NULL,
+	"role" text DEFAULT 'admin' NOT NULL,
+	"created_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "sessions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text,
+	"end_user_id" text,
+	"app_id" text,
+	"label" text,
+	"token_hash" text NOT NULL,
+	"scopes" text DEFAULT 'gateway' NOT NULL,
+	"expires_at" text NOT NULL,
+	"created_at" text NOT NULL,
+	CONSTRAINT "sessions_token_hash_unique" UNIQUE("token_hash")
+);
+--> statement-breakpoint
+CREATE TABLE "signer_config" (
+	"id" text PRIMARY KEY DEFAULT 'default' NOT NULL,
+	"client_id" text,
+	"name" text DEFAULT 'pymthouse signer' NOT NULL,
+	"signer_url" text,
+	"signer_api_key" text,
+	"eth_address" text,
+	"eth_acct_addr" text,
+	"network" text DEFAULT 'arbitrum-one-mainnet' NOT NULL,
+	"eth_rpc_url" text DEFAULT 'https://arb1.arbitrum.io/rpc' NOT NULL,
+	"signer_port" integer DEFAULT 8081 NOT NULL,
+	"status" text DEFAULT 'stopped' NOT NULL,
+	"deposit_wei" text DEFAULT '0',
+	"reserve_wei" text DEFAULT '0',
+	"default_cut_percent" real DEFAULT 15 NOT NULL,
+	"billing_mode" text DEFAULT 'delegated' NOT NULL,
+	"naap_api_key" text,
+	"remote_discovery" integer DEFAULT 0 NOT NULL,
+	"orch_webhook_url" text,
+	"live_ai_cap_report_interval" text,
+	"last_started_at" text,
+	"last_error" text,
+	"created_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "stream_sessions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"end_user_id" text,
+	"app_id" text,
+	"bearer_token_hash" text,
+	"manifest_id" text NOT NULL,
+	"orchestrator_address" text,
+	"total_pixels" integer DEFAULT 0 NOT NULL,
+	"total_fee_wei" text DEFAULT '0' NOT NULL,
+	"price_per_unit" text,
+	"pixels_per_unit" text,
+	"status" text DEFAULT 'active' NOT NULL,
+	"started_at" text NOT NULL,
+	"last_payment_at" text,
+	"ended_at" text
+);
+--> statement-breakpoint
+CREATE TABLE "subscriptions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text,
+	"client_id" text NOT NULL,
+	"plan_id" text NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	"created_at" text NOT NULL,
+	"cancelled_at" text
+);
+--> statement-breakpoint
+CREATE TABLE "transactions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"end_user_id" text,
+	"app_id" text,
+	"client_id" text,
+	"stream_session_id" text,
+	"type" text NOT NULL,
+	"amount_wei" text NOT NULL,
+	"platform_cut_percent" real,
+	"platform_cut_wei" text,
+	"tx_hash" text,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"created_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "usage_records" (
+	"id" text PRIMARY KEY NOT NULL,
+	"request_id" text NOT NULL,
+	"user_id" text,
+	"client_id" text NOT NULL,
+	"model_id" text,
+	"units" text DEFAULT '0' NOT NULL,
+	"fee" text DEFAULT '0' NOT NULL,
+	"created_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" text PRIMARY KEY NOT NULL,
+	"email" text,
+	"name" text,
+	"oauth_provider" text NOT NULL,
+	"oauth_subject" text NOT NULL,
+	"role" text DEFAULT 'developer' NOT NULL,
+	"wallet_address" text,
+	"privy_did" text,
+	"created_at" text NOT NULL,
+	CONSTRAINT "users_privy_did_unique" UNIQUE("privy_did")
+);
+--> statement-breakpoint
+ALTER TABLE "admin_invites" ADD CONSTRAINT "admin_invites_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "admin_invites" ADD CONSTRAINT "admin_invites_used_by_users_id_fk" FOREIGN KEY ("used_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_client_id_developer_apps_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."developer_apps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_subscription_id_subscriptions_id_fk" FOREIGN KEY ("subscription_id") REFERENCES "public"."subscriptions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "app_allowed_domains" ADD CONSTRAINT "app_allowed_domains_app_id_developer_apps_id_fk" FOREIGN KEY ("app_id") REFERENCES "public"."developer_apps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "app_users" ADD CONSTRAINT "app_users_client_id_developer_apps_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."developer_apps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "auth_audit_log" ADD CONSTRAINT "auth_audit_log_client_id_developer_apps_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."developer_apps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "developer_apps" ADD CONSTRAINT "developer_apps_owner_id_users_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "developer_apps" ADD CONSTRAINT "developer_apps_oidc_client_id_oidc_clients_id_fk" FOREIGN KEY ("oidc_client_id") REFERENCES "public"."oidc_clients"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "developer_apps" ADD CONSTRAINT "developer_apps_reviewed_by_users_id_fk" FOREIGN KEY ("reviewed_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oidc_auth_codes" ADD CONSTRAINT "oidc_auth_codes_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oidc_device_codes" ADD CONSTRAINT "oidc_device_codes_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oidc_refresh_tokens" ADD CONSTRAINT "oidc_refresh_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "plan_capability_bundles" ADD CONSTRAINT "plan_capability_bundles_plan_id_plans_id_fk" FOREIGN KEY ("plan_id") REFERENCES "public"."plans"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "plan_capability_bundles" ADD CONSTRAINT "plan_capability_bundles_client_id_developer_apps_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."developer_apps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "plans" ADD CONSTRAINT "plans_client_id_developer_apps_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."developer_apps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "provider_admins" ADD CONSTRAINT "provider_admins_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "provider_admins" ADD CONSTRAINT "provider_admins_client_id_developer_apps_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."developer_apps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_end_user_id_end_users_id_fk" FOREIGN KEY ("end_user_id") REFERENCES "public"."end_users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "signer_config" ADD CONSTRAINT "signer_config_client_id_developer_apps_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."developer_apps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "stream_sessions" ADD CONSTRAINT "stream_sessions_end_user_id_end_users_id_fk" FOREIGN KEY ("end_user_id") REFERENCES "public"."end_users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subscriptions" ADD CONSTRAINT "subscriptions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subscriptions" ADD CONSTRAINT "subscriptions_client_id_developer_apps_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."developer_apps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subscriptions" ADD CONSTRAINT "subscriptions_plan_id_plans_id_fk" FOREIGN KEY ("plan_id") REFERENCES "public"."plans"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "transactions" ADD CONSTRAINT "transactions_end_user_id_end_users_id_fk" FOREIGN KEY ("end_user_id") REFERENCES "public"."end_users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "transactions" ADD CONSTRAINT "transactions_client_id_developer_apps_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."developer_apps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "transactions" ADD CONSTRAINT "transactions_stream_session_id_stream_sessions_id_fk" FOREIGN KEY ("stream_session_id") REFERENCES "public"."stream_sessions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "usage_records" ADD CONSTRAINT "usage_records_client_id_developer_apps_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."developer_apps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_app_users_client_external" ON "app_users" USING btree ("client_id","external_user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_end_users_app_external" ON "end_users" USING btree ("app_id","external_user_id") WHERE "end_users"."app_id" IS NOT NULL AND "end_users"."external_user_id" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "idx_oidc_payloads_uid" ON "oidc_payloads" USING btree ("uid");--> statement-breakpoint
+CREATE INDEX "idx_oidc_payloads_uid_model" ON "oidc_payloads" USING btree ("uid","model");--> statement-breakpoint
+CREATE INDEX "idx_oidc_payloads_user_code" ON "oidc_payloads" USING btree ("user_code");--> statement-breakpoint
+CREATE INDEX "idx_oidc_payloads_grant_id" ON "oidc_payloads" USING btree ("grant_id");--> statement-breakpoint
+CREATE INDEX "idx_oidc_payloads_expires" ON "oidc_payloads" USING btree ("expires_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_plan_capability_bundles_unique" ON "plan_capability_bundles" USING btree ("plan_id","pipeline","model_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_plans_client_name" ON "plans" USING btree ("client_id","name");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_provider_admins_user_client" ON "provider_admins" USING btree ("user_id","client_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_usage_records_client_request" ON "usage_records" USING btree ("client_id","request_id");

--- a/drizzle/0001_add_domain_unique.sql
+++ b/drizzle/0001_add_domain_unique.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX IF NOT EXISTS "app_allowed_domains_app_id_domain_unique" ON "app_allowed_domains" ("app_id", "domain");

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -45,7 +45,29 @@
           "notNull": true
         }
       },
-      "indexes": {},
+      "indexes": {
+        "app_allowed_domains_app_id_domain_unique": {
+          "name": "app_allowed_domains_app_id_domain_unique",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "admin_invites_created_by_users_id_fk": {
           "name": "admin_invites_created_by_users_id_fk",

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -45,29 +45,7 @@
           "notNull": true
         }
       },
-      "indexes": {
-        "app_allowed_domains_app_id_domain_unique": {
-          "name": "app_allowed_domains_app_id_domain_unique",
-          "columns": [
-            {
-              "expression": "app_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "domain",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "admin_invites_created_by_users_id_fk": {
           "name": "admin_invites_created_by_users_id_fk",
@@ -281,7 +259,29 @@
           "notNull": true
         }
       },
-      "indexes": {},
+      "indexes": {
+        "app_allowed_domains_app_id_domain_unique": {
+          "name": "app_allowed_domains_app_id_domain_unique",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "app_allowed_domains_app_id_developer_apps_id_fk": {
           "name": "app_allowed_domains_app_id_developer_apps_id_fk",

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,2605 @@
+{
+  "id": "59028986-ba1a-4d92-83c2-26118aa85b57",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_created_by_users_id_fk": {
+          "name": "admin_invites_created_by_users_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "admin_invites_used_by_users_id_fk": {
+          "name": "admin_invites_used_by_users_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_keys_client_id_developer_apps_id_fk": {
+          "name": "api_keys_client_id_developer_apps_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_keys_subscription_id_subscriptions_id_fk": {
+          "name": "api_keys_subscription_id_subscriptions_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_allowed_domains": {
+      "name": "app_allowed_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cors'"
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_allowed_domains_app_id_developer_apps_id_fk": {
+          "name": "app_allowed_domains_app_id_developer_apps_id_fk",
+          "tableFrom": "app_allowed_domains",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_users": {
+      "name": "app_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_app_users_client_external": {
+          "name": "idx_app_users_client_external",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_users_client_id_developer_apps_id_fk": {
+          "name": "app_users_client_id_developer_apps_id_fk",
+          "tableFrom": "app_users",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_audit_log": {
+      "name": "auth_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_audit_log_client_id_developer_apps_id_fk": {
+          "name": "auth_audit_log_client_id_developer_apps_id_fk",
+          "tableFrom": "auth_audit_log",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.developer_apps": {
+      "name": "developer_apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_client_id": {
+          "name": "oidc_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_light_url": {
+          "name": "logo_light_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_dark_url": {
+          "name": "logo_dark_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "developer_name": {
+          "name": "developer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_url": {
+          "name": "support_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_url": {
+          "name": "tos_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo_recording_url": {
+          "name": "demo_recording_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links_to_purchases": {
+          "name": "links_to_purchases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "reviewer_notes": {
+          "name": "reviewer_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_scopes": {
+          "name": "pending_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_grant_types": {
+          "name": "pending_grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_revision_submitted_at": {
+          "name": "pending_revision_submitted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_mode": {
+          "name": "branding_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blackLabel'"
+        },
+        "custom_login_enabled": {
+          "name": "custom_login_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "custom_login_domain": {
+          "name": "custom_login_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_domain_verified_at": {
+          "name": "custom_domain_verified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_domain_verification_token": {
+          "name": "custom_domain_verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_issuer_enabled": {
+          "name": "custom_issuer_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "custom_issuer_url": {
+          "name": "custom_issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_primary_color": {
+          "name": "branding_primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_logo_url": {
+          "name": "branding_logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_support_email": {
+          "name": "branding_support_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_pattern": {
+          "name": "billing_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app_level'"
+        },
+        "jwks_uri": {
+          "name": "jwks_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "developer_apps_owner_id_users_id_fk": {
+          "name": "developer_apps_owner_id_users_id_fk",
+          "tableFrom": "developer_apps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "developer_apps_oidc_client_id_oidc_clients_id_fk": {
+          "name": "developer_apps_oidc_client_id_oidc_clients_id_fk",
+          "tableFrom": "developer_apps",
+          "tableTo": "oidc_clients",
+          "columnsFrom": [
+            "oidc_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "developer_apps_reviewed_by_users_id_fk": {
+          "name": "developer_apps_reviewed_by_users_id_fk",
+          "tableFrom": "developer_apps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.end_users": {
+      "name": "end_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privy_did": {
+          "name": "privy_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_balance_wei": {
+          "name": "credit_balance_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_end_users_app_external": {
+          "name": "idx_end_users_app_external",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"end_users\".\"app_id\" IS NOT NULL AND \"end_users\".\"external_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "end_users_privy_did_unique": {
+          "name": "end_users_privy_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "privy_did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_auth_codes": {
+      "name": "oidc_auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oidc_auth_codes_user_id_users_id_fk": {
+          "name": "oidc_auth_codes_user_id_users_id_fk",
+          "tableFrom": "oidc_auth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oidc_auth_codes_code_unique": {
+          "name": "oidc_auth_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_clients": {
+      "name": "oidc_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_scopes": {
+          "name": "allowed_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openid profile email'"
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authorization_code,refresh_token'"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiate_login_uri": {
+          "name": "initiate_login_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_uri": {
+          "name": "policy_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_uri": {
+          "name": "tos_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oidc_clients_client_id_unique": {
+          "name": "oidc_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_device_codes": {
+      "name": "oidc_device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_uri": {
+          "name": "verification_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oidc_device_codes_user_id_users_id_fk": {
+          "name": "oidc_device_codes_user_id_users_id_fk",
+          "tableFrom": "oidc_device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oidc_device_codes_device_code_unique": {
+          "name": "oidc_device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "oidc_device_codes_user_code_unique": {
+          "name": "oidc_device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_payloads": {
+      "name": "oidc_payloads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_id": {
+          "name": "grant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_oidc_payloads_uid": {
+          "name": "idx_oidc_payloads_uid",
+          "columns": [
+            {
+              "expression": "uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oidc_payloads_uid_model": {
+          "name": "idx_oidc_payloads_uid_model",
+          "columns": [
+            {
+              "expression": "uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oidc_payloads_user_code": {
+          "name": "idx_oidc_payloads_user_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oidc_payloads_grant_id": {
+          "name": "idx_oidc_payloads_grant_id",
+          "columns": [
+            {
+              "expression": "grant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oidc_payloads_expires": {
+          "name": "idx_oidc_payloads_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oidc_payloads_id_model_pk": {
+          "name": "oidc_payloads_id_model_pk",
+          "columns": [
+            "id",
+            "model"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_refresh_tokens": {
+      "name": "oidc_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oidc_refresh_tokens_user_id_users_id_fk": {
+          "name": "oidc_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "oidc_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oidc_refresh_tokens_token_hash_unique": {
+          "name": "oidc_refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_signing_keys": {
+      "name": "oidc_signing_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kid": {
+          "name": "kid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RS256'"
+        },
+        "public_key_pem": {
+          "name": "public_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key_pem": {
+          "name": "private_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oidc_signing_keys_kid_unique": {
+          "name": "oidc_signing_keys_kid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "kid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_capability_bundles": {
+      "name": "plan_capability_bundles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pipeline": {
+          "name": "pipeline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sla_target_score": {
+          "name": "sla_target_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sla_target_p95_ms": {
+          "name": "sla_target_p95_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_price_per_unit": {
+          "name": "max_price_per_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_plan_capability_bundles_unique": {
+          "name": "idx_plan_capability_bundles_unique",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pipeline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plan_capability_bundles_plan_id_plans_id_fk": {
+          "name": "plan_capability_bundles_plan_id_plans_id_fk",
+          "tableFrom": "plan_capability_bundles",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "plan_capability_bundles_client_id_developer_apps_id_fk": {
+          "name": "plan_capability_bundles_client_id_developer_apps_id_fk",
+          "tableFrom": "plan_capability_bundles",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "price_amount": {
+          "name": "price_amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "price_currency": {
+          "name": "price_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_plans_client_name": {
+          "name": "idx_plans_client_name",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plans_client_id_developer_apps_id_fk": {
+          "name": "plans_client_id_developer_apps_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_admins": {
+      "name": "provider_admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_provider_admins_user_client": {
+          "name": "idx_provider_admins_user_client",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_admins_user_id_users_id_fk": {
+          "name": "provider_admins_user_id_users_id_fk",
+          "tableFrom": "provider_admins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "provider_admins_client_id_developer_apps_id_fk": {
+          "name": "provider_admins_client_id_developer_apps_id_fk",
+          "tableFrom": "provider_admins",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gateway'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sessions_end_user_id_end_users_id_fk": {
+          "name": "sessions_end_user_id_end_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "end_users",
+          "columnsFrom": [
+            "end_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signer_config": {
+      "name": "signer_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pymthouse signer'"
+        },
+        "signer_url": {
+          "name": "signer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signer_api_key": {
+          "name": "signer_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eth_address": {
+          "name": "eth_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eth_acct_addr": {
+          "name": "eth_acct_addr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'arbitrum-one-mainnet'"
+        },
+        "eth_rpc_url": {
+          "name": "eth_rpc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://arb1.arbitrum.io/rpc'"
+        },
+        "signer_port": {
+          "name": "signer_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8081
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stopped'"
+        },
+        "deposit_wei": {
+          "name": "deposit_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "reserve_wei": {
+          "name": "reserve_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "default_cut_percent": {
+          "name": "default_cut_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "billing_mode": {
+          "name": "billing_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'delegated'"
+        },
+        "naap_api_key": {
+          "name": "naap_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_discovery": {
+          "name": "remote_discovery",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "orch_webhook_url": {
+          "name": "orch_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_ai_cap_report_interval": {
+          "name": "live_ai_cap_report_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_started_at": {
+          "name": "last_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signer_config_client_id_developer_apps_id_fk": {
+          "name": "signer_config_client_id_developer_apps_id_fk",
+          "tableFrom": "signer_config",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stream_sessions": {
+      "name": "stream_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bearer_token_hash": {
+          "name": "bearer_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_id": {
+          "name": "manifest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orchestrator_address": {
+          "name": "orchestrator_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pixels": {
+          "name": "total_pixels",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_fee_wei": {
+          "name": "total_fee_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "price_per_unit": {
+          "name": "price_per_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pixels_per_unit": {
+          "name": "pixels_per_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_payment_at": {
+          "name": "last_payment_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stream_sessions_end_user_id_end_users_id_fk": {
+          "name": "stream_sessions_end_user_id_end_users_id_fk",
+          "tableFrom": "stream_sessions",
+          "tableTo": "end_users",
+          "columnsFrom": [
+            "end_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subscriptions_client_id_developer_apps_id_fk": {
+          "name": "subscriptions_client_id_developer_apps_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subscriptions_plan_id_plans_id_fk": {
+          "name": "subscriptions_plan_id_plans_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_session_id": {
+          "name": "stream_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_wei": {
+          "name": "amount_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_cut_percent": {
+          "name": "platform_cut_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_cut_wei": {
+          "name": "platform_cut_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_end_user_id_end_users_id_fk": {
+          "name": "transactions_end_user_id_end_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "end_users",
+          "columnsFrom": [
+            "end_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_client_id_developer_apps_id_fk": {
+          "name": "transactions_client_id_developer_apps_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_stream_session_id_stream_sessions_id_fk": {
+          "name": "transactions_stream_session_id_stream_sessions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "stream_sessions",
+          "columnsFrom": [
+            "stream_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "units": {
+          "name": "units",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "fee": {
+          "name": "fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_records_client_request": {
+          "name": "idx_usage_records_client_request",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_client_id_developer_apps_id_fk": {
+          "name": "usage_records_client_id_developer_apps_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider": {
+          "name": "oauth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_subject": {
+          "name": "oauth_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'developer'"
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privy_did": {
+          "name": "privy_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_privy_did_unique": {
+          "name": "users_privy_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "privy_did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,20 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1775277349992,
+      "tag": "0000_init_pg",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1775363749992,
+      "tag": "0001_add_domain_unique",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "db:prepare": "npx tsx scripts/db-migrate.ts",
     "oidc:seed": "npx tsx scripts/seed-oidc.ts",
     "validate:env": "node scripts/validate-env.js",
-    "test": "node --import tsx --test \"src/**/*.test.ts\""
+    "test": "node --import tsx --test --test-force-exit \"src/**/*.test.ts\""
   },
   "dependencies": {
     "@braintree/sanitize-url": "^7.1.2",

--- a/src/app/api/signer/generate-live-payment/usage-integration.test.ts
+++ b/src/app/api/signer/generate-live-payment/usage-integration.test.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+
+import type { AuthResult } from "@/lib/auth";
+import { validateBearerToken } from "@/lib/auth";
+import { proxyGenerateLivePayment } from "@/lib/signer-proxy";
+import { run } from "@/test-utils/db-guard";
+import {
+  basicAuthHeader,
+  cleanupTestApp,
+  createAppUser,
+  createJobTokenForApp,
+  ensureRunningSigner,
+  seedDeveloperAppWithClient,
+} from "@/test-utils/fixtures";
+import { mockSignerFetch } from "@/test-utils/mock-signer";
+import { buildOrchestratorInfoBase64 } from "@/test-utils/orchestrator-info";
+
+const PER_REQUEST_PIXELS = 1_000_000;
+const PRICE_PER_UNIT = 1_000_000_000;
+const PIXELS_PER_UNIT = 1;
+const PER_REQUEST_FEE_WEI =
+  (BigInt(PER_REQUEST_PIXELS) * BigInt(PRICE_PER_UNIT)) / BigInt(PIXELS_PER_UNIT);
+/** Kept moderate so the suite stays fast on remote DBs; per-request fee is still huge for bigint totals. */
+const VOLUME = 40;
+
+/**
+ * Integration test:
+ *   - Mock the remote signer at the `fetch` boundary.
+ *   - Drive **`proxyGenerateLivePayment`** directly (same code as the HTTP route)
+ *     with cached **`AuthResult`** from **`validateBearerToken`** — avoids Next
+ *     request handling and repeated route auth on every iteration.
+ *   - Validate persistence + bigint totals via **`GET /api/v1/apps/{id}/usage`**
+ *     (Basic auth). Route-level auth for `generate-live-payment` is covered in
+ *     **`proxy-routes.test.ts`**.
+ */
+run("high-volume signer usage is persisted and summarised via Usage API", async (t) => {
+  const { GET: readUsage } = await import("@/app/api/v1/apps/[id]/usage/route");
+
+  const restoreSigner = await ensureRunningSigner();
+  t.after(restoreSigner);
+
+  const app = await seedDeveloperAppWithClient({ status: "approved" });
+  t.after(() => cleanupTestApp(app));
+
+  const ownerToken = await createJobTokenForApp({
+    userId: app.userId,
+    clientId: app.clientId,
+    scopes: "sign:job",
+  });
+
+  const appUserAlpha = await createAppUser({
+    clientId: app.clientId,
+    externalUserId: "ext-alpha",
+  });
+  const appUserBeta = await createAppUser({
+    clientId: app.clientId,
+    externalUserId: "ext-beta",
+  });
+  const alphaToken = await createJobTokenForApp({
+    userId: appUserAlpha.id,
+    clientId: app.clientId,
+    scopes: "sign:job",
+  });
+  const betaToken = await createJobTokenForApp({
+    userId: appUserBeta.id,
+    clientId: app.clientId,
+    scopes: "sign:job",
+  });
+
+  const ownerAuth = await validateBearerToken(ownerToken);
+  const alphaAuth = await validateBearerToken(alphaToken);
+  const betaAuth = await validateBearerToken(betaToken);
+  assert.ok(ownerAuth, "owner token resolves");
+  assert.ok(alphaAuth, "alpha token resolves");
+  assert.ok(betaAuth, "beta token resolves");
+
+  const orch = await buildOrchestratorInfoBase64({
+    pricePerUnit: PRICE_PER_UNIT,
+    pixelsPerUnit: PIXELS_PER_UNIT,
+  });
+
+  const mock = mockSignerFetch({ signerHost: "http://test-signer.invalid" });
+  t.after(mock.restore);
+
+  function paymentBody(requestId: string, manifestId: string): Record<string, unknown> {
+    return {
+      ManifestID: manifestId,
+      RequestID: requestId,
+      InPixels: PER_REQUEST_PIXELS,
+      Orchestrator: orch,
+    };
+  }
+
+  async function sendPayment(auth: AuthResult, requestId: string, manifestId: string) {
+    const result = await proxyGenerateLivePayment(paymentBody(requestId, manifestId), auth);
+    assert.equal(
+      result.status,
+      200,
+      `proxyGenerateLivePayment expected 200, got ${result.status}: ${JSON.stringify(result.body)}`,
+    );
+  }
+
+  // Distribute volume across: owner (no endUser), alpha, beta.
+  const alphaCount = Math.floor(VOLUME * 0.4);
+  const betaCount = Math.floor(VOLUME * 0.3);
+  const ownerCount = VOLUME - alphaCount - betaCount;
+
+  let successes = 0;
+
+  for (let i = 0; i < ownerCount; i++) {
+    await sendPayment(ownerAuth!, `owner-req-${i}`, `owner-manifest-${i}`);
+    successes++;
+  }
+  for (let i = 0; i < alphaCount; i++) {
+    await sendPayment(alphaAuth!, `alpha-req-${i}`, `alpha-manifest-${i}`);
+    successes++;
+  }
+  for (let i = 0; i < betaCount; i++) {
+    await sendPayment(betaAuth!, `beta-req-${i}`, `beta-manifest-${i}`);
+    successes++;
+  }
+
+  assert.equal(successes, VOLUME);
+  assert.equal(
+    mock.calls.filter((c) => c.url.endsWith("/generate-live-payment")).length,
+    VOLUME,
+    "every payment should have been forwarded to the mocked signer exactly once",
+  );
+
+  // Idempotency / dedupe: re-sending the same requestId twice should not
+  // produce additional usage rows.
+  await sendPayment(ownerAuth!, "dupe-req-0", "dupe-manifest-0");
+  await sendPayment(ownerAuth!, "dupe-req-0", "dupe-manifest-0");
+
+  const expectedRequestCount = VOLUME + 1;
+  const expectedTotalFeeWei = (PER_REQUEST_FEE_WEI * BigInt(expectedRequestCount)).toString();
+
+  async function fetchUsage(query = "") {
+    const res = await readUsage(
+      new Request(`http://localhost/api/v1/apps/${app.clientId}/usage${query}`, {
+        method: "GET",
+        headers: {
+          Authorization: basicAuthHeader(app.clientId, app.clientSecret),
+        },
+      }) as never,
+      { params: Promise.resolve({ id: app.clientId }) },
+    );
+    return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+  }
+
+  const overall = await fetchUsage();
+  assert.equal(overall.status, 200);
+  assert.equal((overall.body as { clientId: string }).clientId, app.clientId);
+  const totals = (overall.body as { totals: { requestCount: number; totalFeeWei: string } }).totals;
+  assert.equal(totals.requestCount, expectedRequestCount, "one row per unique requestId");
+  assert.equal(totals.totalFeeWei, expectedTotalFeeWei, "bigint sum matches pricePerUnit * pixels * volume");
+
+  const byUser = await fetchUsage("?groupBy=user");
+  assert.equal(byUser.status, 200);
+  const buckets = (byUser.body as {
+    byUser?: {
+      endUserId: string;
+      externalUserId: string | null;
+      feeWei: string;
+      requestCount: number;
+    }[];
+  }).byUser;
+  assert.ok(Array.isArray(buckets), "byUser array present when groupBy=user");
+  assert.equal(buckets!.length, 3, "three buckets: owner(user), alpha, beta");
+
+  const alphaBucket = buckets!.find((b) => b.endUserId === appUserAlpha.id);
+  const betaBucket = buckets!.find((b) => b.endUserId === appUserBeta.id);
+  const ownerBucket = buckets!.find((b) => b.endUserId === app.userId);
+
+  assert.ok(alphaBucket, "alpha end user present in byUser");
+  assert.equal(alphaBucket!.externalUserId, "ext-alpha");
+  assert.equal(alphaBucket!.requestCount, alphaCount);
+  assert.equal(
+    alphaBucket!.feeWei,
+    (PER_REQUEST_FEE_WEI * BigInt(alphaCount)).toString(),
+  );
+
+  assert.ok(betaBucket, "beta end user present in byUser");
+  assert.equal(betaBucket!.externalUserId, "ext-beta");
+  assert.equal(betaBucket!.requestCount, betaCount);
+  assert.equal(
+    betaBucket!.feeWei,
+    (PER_REQUEST_FEE_WEI * BigInt(betaCount)).toString(),
+  );
+
+  assert.ok(ownerBucket, "owner userId bucket present");
+  assert.equal(ownerBucket!.externalUserId, null, "owner is a platform user, not an app_user");
+  assert.equal(ownerBucket!.requestCount, ownerCount + 1, "owner bucket includes dedup single row");
+
+  // userId filter: only alpha rows.
+  const alphaOnly = await fetchUsage(`?userId=${encodeURIComponent(appUserAlpha.id)}`);
+  assert.equal(alphaOnly.status, 200);
+  const alphaTotals = (alphaOnly.body as { totals: { requestCount: number; totalFeeWei: string } }).totals;
+  assert.equal(alphaTotals.requestCount, alphaCount);
+  assert.equal(
+    alphaTotals.totalFeeWei,
+    (PER_REQUEST_FEE_WEI * BigInt(alphaCount)).toString(),
+  );
+
+  // Date window that excludes all rows -> zero totals.
+  const emptyWindow = await fetchUsage(
+    "?startDate=1970-01-01T00:00:00.000Z&endDate=1970-01-02T00:00:00.000Z",
+  );
+  assert.equal(emptyWindow.status, 200);
+  const emptyTotals = (emptyWindow.body as { totals: { requestCount: number; totalFeeWei: string } }).totals;
+  assert.equal(emptyTotals.requestCount, 0);
+  assert.equal(emptyTotals.totalFeeWei, "0");
+
+  // Invalid date parameter -> 400.
+  const badDate = await readUsage(
+    new Request(`http://localhost/api/v1/apps/${app.clientId}/usage?startDate=not-a-date`, {
+      method: "GET",
+      headers: {
+        Authorization: basicAuthHeader(app.clientId, app.clientSecret),
+      },
+    }) as never,
+    { params: Promise.resolve({ id: app.clientId }) },
+  );
+  assert.equal(badDate.status, 400);
+});

--- a/src/app/api/signer/proxy-routes.test.ts
+++ b/src/app/api/signer/proxy-routes.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+
+import { run } from "@/test-utils/db-guard";
+import {
+  cleanupTestApp,
+  createJobTokenForApp,
+  ensureRunningSigner,
+  seedDeveloperAppWithClient,
+} from "@/test-utils/fixtures";
+import { mockSignerFetch } from "@/test-utils/mock-signer";
+import { buildOrchestratorInfoBase64 } from "@/test-utils/orchestrator-info";
+
+/**
+ * Coverage for the remaining signer proxy routes: confirms scope/auth
+ * enforcement and that successful calls are forwarded to the mocked signer.
+ */
+run("signer proxy routes enforce auth and forward to the signer", async (t) => {
+  const { POST: signOrchestratorInfo } = await import("./sign-orchestrator-info/route");
+  const { POST: signByocJob } = await import("./sign-byoc-job/route");
+  const { GET: discoverOrchestrators } = await import("./discover-orchestrators/route");
+  const { POST: generateLivePayment } = await import("./generate-live-payment/route");
+
+  const restoreSigner = await ensureRunningSigner();
+  t.after(restoreSigner);
+
+  const app = await seedDeveloperAppWithClient({ status: "approved" });
+  t.after(() => cleanupTestApp(app));
+
+  const jobToken = await createJobTokenForApp({
+    userId: app.userId,
+    clientId: app.clientId,
+    scopes: "sign:job",
+  });
+
+  const wrongScopeToken = await createJobTokenForApp({
+    userId: app.userId,
+    clientId: app.clientId,
+    scopes: "openid",
+  });
+
+  const mock = mockSignerFetch();
+  t.after(mock.restore);
+
+  // Each POST route rejects without Authorization.
+  for (const [route, url] of [
+    [signOrchestratorInfo, "http://localhost/api/signer/sign-orchestrator-info"],
+    [signByocJob, "http://localhost/api/signer/sign-byoc-job"],
+    [generateLivePayment, "http://localhost/api/signer/generate-live-payment"],
+  ] as const) {
+    const res = await route(
+      new Request(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      }) as never,
+    );
+    assert.equal(res.status, 401, `${url} without auth returns 401`);
+  }
+
+  const discoverNoAuth = await discoverOrchestrators(
+    new Request("http://localhost/api/signer/discover-orchestrators") as never,
+  );
+  assert.equal(discoverNoAuth.status, 401);
+
+  // Missing sign:job scope -> 403.
+  const forbidden = await signOrchestratorInfo(
+    new Request("http://localhost/api/signer/sign-orchestrator-info", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${wrongScopeToken}`,
+      },
+      body: "{}",
+    }) as never,
+  );
+  assert.equal(forbidden.status, 403);
+
+  // Happy path for each: routes forward to mocked signer and surface its body.
+  const siRes = await signOrchestratorInfo(
+    new Request("http://localhost/api/signer/sign-orchestrator-info", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${jobToken}`,
+      },
+      body: JSON.stringify({ manifestId: "abc" }),
+    }) as never,
+  );
+  assert.equal(siRes.status, 200);
+  const siBody = (await siRes.json()) as { signedData: string };
+  assert.equal(siBody.signedData, "mock-signed");
+
+  const byocRes = await signByocJob(
+    new Request("http://localhost/api/signer/sign-byoc-job", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${jobToken}`,
+      },
+      body: JSON.stringify({ job: "xyz" }),
+    }) as never,
+  );
+  assert.equal(byocRes.status, 200);
+  const byocBody = (await byocRes.json()) as { signedJob: string };
+  assert.equal(byocBody.signedJob, "mock-signed");
+
+  const discoverRes = await discoverOrchestrators(
+    new Request("http://localhost/api/signer/discover-orchestrators", {
+      method: "GET",
+      headers: { Authorization: `Bearer ${jobToken}` },
+    }) as never,
+  );
+  assert.equal(discoverRes.status, 200);
+  const discoverBody = (await discoverRes.json()) as { orchestrators: unknown[] };
+  assert.ok(Array.isArray(discoverBody.orchestrators));
+
+  // Confirm every call above went to the mocked signer host.
+  assert.ok(mock.calls.every((c) => c.url.startsWith("http://test-signer.invalid")));
+});
+
+run("generate-live-payment rejects requests against unapproved apps", async (t) => {
+  const { POST: generateLivePayment } = await import("./generate-live-payment/route");
+
+  const restoreSigner = await ensureRunningSigner();
+  t.after(restoreSigner);
+
+  const app = await seedDeveloperAppWithClient({ status: "draft" });
+  t.after(() => cleanupTestApp(app));
+
+  const strangerUserId = await (await import("@/test-utils/fixtures")).createTestUser();
+  t.after(async () => {
+    const { db } = await import("@/db/index");
+    const { users } = await import("@/db/schema");
+    const { eq } = await import("drizzle-orm");
+    await db.delete(users).where(eq(users.id, strangerUserId));
+  });
+
+  const strangerToken = await createJobTokenForApp({
+    userId: strangerUserId,
+    clientId: app.clientId,
+    scopes: "sign:job",
+  });
+
+  const orch = await buildOrchestratorInfoBase64({
+    pricePerUnit: 100,
+    pixelsPerUnit: 1,
+  });
+
+  const mock = mockSignerFetch();
+  t.after(mock.restore);
+
+  const res = await generateLivePayment(
+    new Request("http://localhost/api/signer/generate-live-payment", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${strangerToken}`,
+      },
+      body: JSON.stringify({
+        ManifestID: "m1",
+        RequestID: "r1",
+        InPixels: 100,
+        Orchestrator: orch,
+      }),
+    }) as never,
+  );
+  assert.equal(res.status, 403, "non-owner tokens on unapproved apps return 403");
+  const body = (await res.json()) as { error: string };
+  assert.equal(body.error, "app_not_approved");
+  assert.equal(
+    mock.calls.length,
+    0,
+    "approval check happens before any signer forwarding",
+  );
+});

--- a/src/app/api/signer/proxy-routes.test.ts
+++ b/src/app/api/signer/proxy-routes.test.ts
@@ -4,6 +4,7 @@ import { run } from "@/test-utils/db-guard";
 import {
   cleanupTestApp,
   createJobTokenForApp,
+  createTestUserWithCleanup,
   ensureRunningSigner,
   seedDeveloperAppWithClient,
 } from "@/test-utils/fixtures";
@@ -115,7 +116,16 @@ run("signer proxy routes enforce auth and forward to the signer", async (t) => {
   assert.ok(Array.isArray(discoverBody.orchestrators));
 
   // Confirm every call above went to the mocked signer host.
-  assert.ok(mock.calls.every((c) => c.url.startsWith("http://test-signer.invalid")));
+  const expectedSignerOrigin = new URL("http://test-signer.invalid").origin;
+  assert.ok(
+    mock.calls.every((c) => {
+      try {
+        return new URL(c.url).origin === expectedSignerOrigin;
+      } catch {
+        return false;
+      }
+    }),
+  );
 });
 
 run("generate-live-payment rejects requests against unapproved apps", async (t) => {
@@ -127,13 +137,7 @@ run("generate-live-payment rejects requests against unapproved apps", async (t) 
   const app = await seedDeveloperAppWithClient({ status: "draft" });
   t.after(() => cleanupTestApp(app));
 
-  const strangerUserId = await (await import("@/test-utils/fixtures")).createTestUser();
-  t.after(async () => {
-    const { db } = await import("@/db/index");
-    const { users } = await import("@/db/schema");
-    const { eq } = await import("drizzle-orm");
-    await db.delete(users).where(eq(users.id, strangerUserId));
-  });
+  const strangerUserId = await createTestUserWithCleanup(t);
 
   const strangerToken = await createJobTokenForApp({
     userId: strangerUserId,

--- a/src/app/api/v1/apps/[id]/usage/route.test.ts
+++ b/src/app/api/v1/apps/[id]/usage/route.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+
+import { run } from "@/test-utils/db-guard";
+import {
+  basicAuthHeader,
+  cleanupTestApp,
+  createAppUser,
+  seedDeveloperAppWithClient,
+} from "@/test-utils/fixtures";
+
+async function seedUsage(opts: {
+  clientId: string;
+  userId: string | null;
+  feeWei: bigint;
+  units?: bigint;
+  createdAt?: string;
+  requestId?: string;
+}) {
+  const { db } = await import("@/db/index");
+  const { usageRecords } = await import("@/db/schema");
+  await db.insert(usageRecords).values({
+    id: randomUUID(),
+    requestId: opts.requestId ?? randomUUID(),
+    clientId: opts.clientId,
+    userId: opts.userId,
+    units: (opts.units ?? 1n).toString(),
+    fee: opts.feeWei.toString(),
+    createdAt: opts.createdAt ?? new Date().toISOString(),
+  });
+}
+
+run("usage API requires a matching client or authorized session", async (t) => {
+  const { GET } = await import("./route");
+  const app = await seedDeveloperAppWithClient({ status: "approved" });
+  t.after(() => cleanupTestApp(app));
+
+  // No auth -> 404 (handler deliberately opaque).
+  const anonymous = await GET(
+    new Request(`http://localhost/api/v1/apps/${app.clientId}/usage`) as never,
+    { params: Promise.resolve({ id: app.clientId }) },
+  );
+  assert.equal(anonymous.status, 404);
+
+  // Wrong secret -> 404.
+  const wrong = await GET(
+    new Request(`http://localhost/api/v1/apps/${app.clientId}/usage`, {
+      headers: { Authorization: basicAuthHeader(app.clientId, "pmth_cs_nope") },
+    }) as never,
+    { params: Promise.resolve({ id: app.clientId }) },
+  );
+  assert.equal(wrong.status, 404);
+
+  // Basic auth for client A cannot read client B's usage.
+  const other = await seedDeveloperAppWithClient({ status: "approved" });
+  t.after(() => cleanupTestApp(other));
+  const crossTenant = await GET(
+    new Request(`http://localhost/api/v1/apps/${other.clientId}/usage`, {
+      headers: { Authorization: basicAuthHeader(app.clientId, app.clientSecret) },
+    }) as never,
+    { params: Promise.resolve({ id: other.clientId }) },
+  );
+  assert.equal(crossTenant.status, 404);
+
+  // Correct Basic auth -> 200.
+  const ok = await GET(
+    new Request(`http://localhost/api/v1/apps/${app.clientId}/usage`, {
+      headers: { Authorization: basicAuthHeader(app.clientId, app.clientSecret) },
+    }) as never,
+    { params: Promise.resolve({ id: app.clientId }) },
+  );
+  assert.equal(ok.status, 200);
+});
+
+run("usage API aggregates seeded rows, filters by date and user, and validates input", async (t) => {
+  const { GET } = await import("./route");
+
+  const app = await seedDeveloperAppWithClient({ status: "approved" });
+  t.after(() => cleanupTestApp(app));
+
+  const alpha = await createAppUser({
+    clientId: app.clientId,
+    externalUserId: "alpha-ext",
+  });
+  const beta = await createAppUser({
+    clientId: app.clientId,
+    externalUserId: "beta-ext",
+  });
+
+  const inside1 = "2026-06-01T00:00:00.000Z";
+  const inside2 = "2026-06-15T00:00:00.000Z";
+  const outside = "2020-01-01T00:00:00.000Z";
+
+  await seedUsage({ clientId: app.clientId, userId: alpha.id, feeWei: 1_000_000_000_000_000n, createdAt: inside1 });
+  await seedUsage({ clientId: app.clientId, userId: alpha.id, feeWei: 2_000_000_000_000_000n, createdAt: inside2 });
+  await seedUsage({ clientId: app.clientId, userId: beta.id, feeWei: 500_000_000_000_000n, createdAt: inside1 });
+  await seedUsage({ clientId: app.clientId, userId: null, feeWei: 10n, createdAt: inside2 });
+  await seedUsage({ clientId: app.clientId, userId: alpha.id, feeWei: 7n, createdAt: outside });
+
+  async function call(query = "") {
+    const res = await GET(
+      new Request(`http://localhost/api/v1/apps/${app.clientId}/usage${query}`, {
+        headers: { Authorization: basicAuthHeader(app.clientId, app.clientSecret) },
+      }) as never,
+      { params: Promise.resolve({ id: app.clientId }) },
+    );
+    return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+  }
+
+  // Totals across all rows.
+  const all = await call();
+  assert.equal(all.status, 200);
+  const allTotals = (all.body as { totals: { requestCount: number; totalFeeWei: string } }).totals;
+  assert.equal(allTotals.requestCount, 5);
+  assert.equal(
+    allTotals.totalFeeWei,
+    (1_000_000_000_000_000n + 2_000_000_000_000_000n + 500_000_000_000_000n + 10n + 7n).toString(),
+  );
+
+  // Date-windowed totals exclude the "outside" row.
+  const windowed = await call(`?startDate=2026-05-01T00:00:00.000Z&endDate=2026-07-01T00:00:00.000Z`);
+  assert.equal(windowed.status, 200);
+  const windowedTotals = (windowed.body as { totals: { requestCount: number; totalFeeWei: string } }).totals;
+  assert.equal(windowedTotals.requestCount, 4);
+  assert.equal(
+    windowedTotals.totalFeeWei,
+    (1_000_000_000_000_000n + 2_000_000_000_000_000n + 500_000_000_000_000n + 10n).toString(),
+  );
+
+  // userId filter narrows to one app_user.
+  const betaOnly = await call(`?userId=${encodeURIComponent(beta.id)}`);
+  assert.equal(betaOnly.status, 200);
+  const betaTotals = (betaOnly.body as { totals: { requestCount: number; totalFeeWei: string } }).totals;
+  assert.equal(betaTotals.requestCount, 1);
+  assert.equal(betaTotals.totalFeeWei, "500000000000000");
+
+  // groupBy=user exposes external ids and an "unknown" bucket for null user_id rows.
+  const grouped = await call("?groupBy=user");
+  const buckets = (grouped.body as {
+    byUser: { endUserId: string; externalUserId: string | null; requestCount: number; feeWei: string }[];
+  }).byUser;
+  assert.equal(buckets.length, 3);
+  const byId = new Map(buckets.map((b) => [b.endUserId, b]));
+  assert.equal(byId.get(alpha.id)!.externalUserId, "alpha-ext");
+  assert.equal(byId.get(alpha.id)!.requestCount, 3);
+  assert.equal(byId.get(beta.id)!.externalUserId, "beta-ext");
+  assert.equal(byId.get("unknown")!.externalUserId, null);
+  assert.equal(byId.get("unknown")!.requestCount, 1);
+
+  // Input validation.
+  const badStart = await call("?startDate=not-a-date");
+  assert.equal(badStart.status, 400);
+  const badEnd = await call("?endDate=still-not-a-date");
+  assert.equal(badEnd.status, 400);
+});

--- a/src/app/api/v1/apps/[id]/usage/route.ts
+++ b/src/app/api/v1/apps/[id]/usage/route.ts
@@ -19,7 +19,14 @@ export async function GET(
   if (clientAuth?.appId === clientId) {
     app = await getProviderApp(clientId);
   } else {
-    const providerAuth = await getAuthorizedProviderApp(clientId);
+    let providerAuth: Awaited<ReturnType<typeof getAuthorizedProviderApp>> | null = null;
+    try {
+      providerAuth = await getAuthorizedProviderApp(clientId);
+    } catch {
+      // node:test imports route handlers directly, outside Next request scope.
+      // In that context getServerSession()/headers() throws; treat as no auth.
+      providerAuth = null;
+    }
     if (!providerAuth) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }

--- a/src/app/api/v1/apps/[id]/usage/route.ts
+++ b/src/app/api/v1/apps/[id]/usage/route.ts
@@ -11,11 +11,21 @@ export async function GET(
 ) {
   const { id: clientId } = await params;
   const clientAuth = await authenticateAppClient(request);
-  const providerAuth = await getAuthorizedProviderApp(clientId);
-  if (!providerAuth && clientAuth?.appId !== clientId) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  // Prefer Basic-auth path: it does not need Next request context. Calling
+  // getAuthorizedProviderApp (session) pulls in headers() and throws outside
+  // a request scope (e.g. node:test calling the handler directly).
+  let app: Awaited<ReturnType<typeof getProviderApp>> | null = null;
+  if (clientAuth?.appId === clientId) {
+    app = await getProviderApp(clientId);
+  } else {
+    const providerAuth = await getAuthorizedProviderApp(clientId);
+    if (!providerAuth) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    app = providerAuth.app;
   }
-  const app = providerAuth?.app ?? (await getProviderApp(clientId));
+
   if (!app) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }

--- a/src/test-utils/db-guard.ts
+++ b/src/test-utils/db-guard.ts
@@ -1,0 +1,7 @@
+import test from "node:test";
+
+/**
+ * Gate DB-backed integration tests behind DATABASE_URL so local runs and CI
+ * jobs without Postgres silently skip (same pattern as existing *.test.ts files).
+ */
+export const run = process.env.DATABASE_URL ? test : test.skip;

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -144,45 +144,34 @@ export async function createAppUser(opts: {
  * forward requests. Returns a restore function that resets any captured state.
  */
 export async function ensureRunningSigner(): Promise<() => Promise<void>> {
-  const existingRows = await db
+  const defaultSignerRows = await db
     .select()
     .from(signerConfig)
     .where(eq(signerConfig.id, "default"))
     .limit(1);
-  const existing = existingRows[0];
-
-  if (existing) {
+  const defaultSigner = defaultSignerRows[0];
+  if (defaultSigner) {
     await db
       .update(signerConfig)
       .set({ status: "running", signerUrl: "http://test-signer.invalid" })
       .where(eq(signerConfig.id, "default"));
-
-    return async () => {
-      await db
-        .update(signerConfig)
-        .set({
-          status: existing.status,
-          signerUrl: existing.signerUrl,
-        })
-        .where(eq(signerConfig.id, "default"));
-    };
+  } else {
+    await db.insert(signerConfig).values({
+      id: "default",
+      name: "pymthouse test signer",
+      signerUrl: "http://test-signer.invalid",
+      status: "running",
+      network: "arbitrum-one-mainnet",
+      ethRpcUrl: "https://arb1.arbitrum.io/rpc",
+      signerPort: 8081,
+      defaultCutPercent: 15,
+      billingMode: "delegated",
+    });
   }
 
-  await db.insert(signerConfig).values({
-    id: "default",
-    name: "pymthouse test signer",
-    signerUrl: "http://test-signer.invalid",
-    status: "running",
-    network: "arbitrum-one-mainnet",
-    ethRpcUrl: "https://arb1.arbitrum.io/rpc",
-    signerPort: 8081,
-    defaultCutPercent: 15,
-    billingMode: "delegated",
-  });
-
-  return async () => {
-    await db.delete(signerConfig).where(eq(signerConfig.id, "default"));
-  };
+  // Tests run in parallel; restoring signer status in each test can flip a
+  // shared row back to "stopped" while another test still needs it.
+  return async () => {};
 }
 
 /**

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -1,0 +1,240 @@
+import { randomUUID } from "node:crypto";
+import { eq, inArray } from "drizzle-orm";
+
+import { db } from "@/db/index";
+import {
+  apiKeys,
+  appAllowedDomains,
+  appUsers,
+  authAuditLog,
+  developerApps,
+  endUsers,
+  oidcAuthCodes,
+  oidcClients,
+  oidcDeviceCodes,
+  oidcRefreshTokens,
+  planCapabilityBundles,
+  plans,
+  providerAdmins,
+  sessions,
+  signerConfig,
+  streamSessions,
+  subscriptions,
+  transactions,
+  usageRecords,
+  users,
+} from "@/db/schema";
+import { createAppClient, rotateClientSecret } from "@/lib/oidc/clients";
+import { createSession } from "@/lib/auth";
+
+export interface SeededDeveloperApp {
+  /**
+   * Public OIDC client_id and developer_apps.id (they are the same string in this
+   * project, matching the POST /api/v1/apps handler which sets `appId = clientId`).
+   */
+  clientId: string;
+  /**
+   * Internal primary key of the oidc_clients row (UUID, different from clientId).
+   */
+  oidcClientRowId: string;
+  userId: string;
+  clientSecret: string;
+}
+
+export async function createTestUser(opts?: { id?: string; role?: string }): Promise<string> {
+  const id = opts?.id ?? `user-test-${randomUUID()}`;
+  await db.insert(users).values({
+    id,
+    email: `${id}@example.test`,
+    name: "Test User",
+    oauthProvider: "bootstrap",
+    oauthSubject: id,
+    role: opts?.role ?? "developer",
+  });
+  return id;
+}
+
+export async function seedDeveloperAppWithClient(opts?: {
+  status?: "draft" | "submitted" | "in_review" | "approved" | "rejected";
+  ownerId?: string;
+  name?: string;
+}): Promise<SeededDeveloperApp> {
+  const status = opts?.status ?? "approved";
+  const userId = opts?.ownerId ?? (await createTestUser());
+  const displayName = opts?.name ?? `Test App ${randomUUID().slice(0, 8)}`;
+
+  const { id: oidcClientRowId, clientId } = await createAppClient(displayName);
+
+  const clientSecret = await rotateClientSecret(clientId);
+  if (!clientSecret) {
+    throw new Error("Failed to rotate client secret for test fixture");
+  }
+
+  const now = new Date().toISOString();
+  await db.insert(developerApps).values({
+    id: clientId,
+    ownerId: userId,
+    oidcClientId: oidcClientRowId,
+    name: displayName,
+    status,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return { clientId, oidcClientRowId, userId, clientSecret };
+}
+
+export async function createJobTokenForApp(opts: {
+  userId?: string;
+  endUserId?: string;
+  clientId: string;
+  scopes?: string;
+}): Promise<string> {
+  const { token } = await createSession({
+    userId: opts.userId,
+    endUserId: opts.endUserId,
+    appId: opts.clientId,
+    scopes: opts.scopes ?? "sign:job",
+    expiresInDays: 1,
+  });
+  return token;
+}
+
+/**
+ * Create a provider-managed `app_users` row alongside a matching platform
+ * `users` row that shares the same primary key. This mirrors how the Usage API
+ * groups `usage_records.user_id` by joining to `app_users.id`, while still
+ * satisfying the FK from `sessions.user_id` so we can mint bearer tokens for
+ * this user without touching the legacy `end_users` table.
+ */
+export async function createAppUser(opts: {
+  clientId: string;
+  externalUserId: string;
+}): Promise<{ id: string; externalUserId: string }> {
+  const id = `app-user-${randomUUID()}`;
+  await createTestUser({ id });
+  await db.insert(appUsers).values({
+    id,
+    clientId: opts.clientId,
+    externalUserId: opts.externalUserId,
+    status: "active",
+  });
+  return { id, externalUserId: opts.externalUserId };
+}
+
+/**
+ * Ensure the default signer row exists and is marked running so proxy routes
+ * forward requests. Returns a restore function that resets any captured state.
+ */
+export async function ensureRunningSigner(): Promise<() => Promise<void>> {
+  const existingRows = await db
+    .select()
+    .from(signerConfig)
+    .where(eq(signerConfig.id, "default"))
+    .limit(1);
+  const existing = existingRows[0];
+
+  if (existing) {
+    await db
+      .update(signerConfig)
+      .set({ status: "running", signerUrl: "http://test-signer.invalid" })
+      .where(eq(signerConfig.id, "default"));
+
+    return async () => {
+      await db
+        .update(signerConfig)
+        .set({
+          status: existing.status,
+          signerUrl: existing.signerUrl,
+        })
+        .where(eq(signerConfig.id, "default"));
+    };
+  }
+
+  await db.insert(signerConfig).values({
+    id: "default",
+    name: "pymthouse test signer",
+    signerUrl: "http://test-signer.invalid",
+    status: "running",
+    network: "arbitrum-one-mainnet",
+    ethRpcUrl: "https://arb1.arbitrum.io/rpc",
+    signerPort: 8081,
+    defaultCutPercent: 15,
+    billingMode: "delegated",
+  });
+
+  return async () => {
+    await db.delete(signerConfig).where(eq(signerConfig.id, "default"));
+  };
+}
+
+/**
+ * Remove everything inserted under a seeded developer app (including the
+ * oidc client row, the owner user, usage rows, and any test sessions scoped
+ * to the client). Safe to call even when some of the related rows are missing.
+ */
+export async function cleanupTestApp(app: SeededDeveloperApp): Promise<void> {
+  const appId = app.clientId;
+  const oidcClientPublic = app.clientId;
+  const oidcClientPk = app.oidcClientRowId;
+  const ownerId = app.userId;
+
+  await db.delete(sessions).where(eq(sessions.appId, oidcClientPublic));
+
+  await db.delete(oidcAuthCodes).where(eq(oidcAuthCodes.clientId, oidcClientPublic));
+  await db.delete(oidcRefreshTokens).where(eq(oidcRefreshTokens.clientId, oidcClientPublic));
+  await db.delete(oidcDeviceCodes).where(eq(oidcDeviceCodes.clientId, oidcClientPublic));
+
+  await db.delete(apiKeys).where(eq(apiKeys.clientId, appId));
+  await db.delete(subscriptions).where(eq(subscriptions.clientId, appId));
+  await db.delete(planCapabilityBundles).where(eq(planCapabilityBundles.clientId, appId));
+  await db.delete(plans).where(eq(plans.clientId, appId));
+
+  await db.delete(usageRecords).where(eq(usageRecords.clientId, appId));
+  await db.delete(authAuditLog).where(eq(authAuditLog.clientId, appId));
+  await db.delete(appAllowedDomains).where(eq(appAllowedDomains.appId, appId));
+
+  const appUserRows = await db
+    .select({ id: appUsers.id })
+    .from(appUsers)
+    .where(eq(appUsers.clientId, appId));
+  const appUserIds = appUserRows.map((row) => row.id);
+  if (appUserIds.length > 0) {
+    await db
+      .delete(sessions)
+      .where(inArray(sessions.userId, appUserIds));
+  }
+  await db.delete(appUsers).where(eq(appUsers.clientId, appId));
+  await db.delete(providerAdmins).where(eq(providerAdmins.clientId, appId));
+
+  const endUserRows = await db
+    .select({ id: endUsers.id })
+    .from(endUsers)
+    .where(eq(endUsers.appId, appId));
+  const endUserIds = endUserRows.map((row) => row.id);
+
+  if (endUserIds.length > 0) {
+    await db
+      .delete(transactions)
+      .where(inArray(transactions.endUserId, endUserIds));
+    await db
+      .delete(streamSessions)
+      .where(inArray(streamSessions.endUserId, endUserIds));
+  }
+
+  await db.delete(streamSessions).where(eq(streamSessions.appId, appId));
+  await db.delete(transactions).where(eq(transactions.clientId, appId));
+  await db.delete(transactions).where(eq(transactions.appId, appId));
+  await db.delete(endUsers).where(eq(endUsers.appId, appId));
+
+  await db.delete(developerApps).where(eq(developerApps.id, appId));
+  await db.delete(oidcClients).where(eq(oidcClients.id, oidcClientPk));
+  if (appUserIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, appUserIds));
+  }
+  await db.delete(users).where(eq(users.id, ownerId));
+}
+
+export function basicAuthHeader(clientId: string, clientSecret: string): string {
+  return "Basic " + Buffer.from(`${clientId}:${clientSecret}`, "utf8").toString("base64");
+}

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import type { TestContext } from "node:test";
 import { eq, inArray } from "drizzle-orm";
 
 import { db } from "@/db/index";
@@ -50,6 +51,22 @@ export async function createTestUser(opts?: { id?: string; role?: string }): Pro
     oauthProvider: "bootstrap",
     oauthSubject: id,
     role: opts?.role ?? "developer",
+  });
+  return id;
+}
+
+/**
+ * Creates a platform user and registers teardown to delete that row. Use for
+ * tests that need an extra user outside {@link cleanupTestApp} (e.g. a
+ * non-owner session against another user's app).
+ */
+export async function createTestUserWithCleanup(
+  t: Pick<TestContext, "after">,
+  opts?: { id?: string; role?: string },
+): Promise<string> {
+  const id = await createTestUser(opts);
+  t.after(async () => {
+    await db.delete(users).where(eq(users.id, id));
   });
   return id;
 }

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -4,25 +4,9 @@ import { eq, inArray } from "drizzle-orm";
 
 import { db } from "@/db/index";
 import {
-  apiKeys,
-  appAllowedDomains,
   appUsers,
-  authAuditLog,
   developerApps,
-  endUsers,
-  oidcAuthCodes,
-  oidcClients,
-  oidcDeviceCodes,
-  oidcRefreshTokens,
-  planCapabilityBundles,
-  plans,
-  providerAdmins,
-  sessions,
   signerConfig,
-  streamSessions,
-  subscriptions,
-  transactions,
-  usageRecords,
   users,
 } from "@/db/schema";
 import { createAppClient, rotateClientSecret } from "@/lib/oidc/clients";
@@ -179,66 +163,76 @@ export async function ensureRunningSigner(): Promise<() => Promise<void>> {
  * oidc client row, the owner user, usage rows, and any test sessions scoped
  * to the client). Safe to call even when some of the related rows are missing.
  */
-export async function cleanupTestApp(app: SeededDeveloperApp): Promise<void> {
+export async function cleanupTestApp(
+  app: SeededDeveloperApp | undefined | null,
+): Promise<void> {
+  if (!app?.clientId || !app.oidcClientRowId || !app.userId) {
+    return;
+  }
+
+  // Dynamic import avoids rare ESM circular-init cases where top-level named
+  // table imports are still undefined when `t.after` teardown runs (seen on CI).
+  const m = await import("@/db/schema");
+
   const appId = app.clientId;
   const oidcClientPublic = app.clientId;
   const oidcClientPk = app.oidcClientRowId;
   const ownerId = app.userId;
 
-  await db.delete(sessions).where(eq(sessions.appId, oidcClientPublic));
+  await db.delete(m.sessions).where(eq(m.sessions.appId, oidcClientPublic));
 
-  await db.delete(oidcAuthCodes).where(eq(oidcAuthCodes.clientId, oidcClientPublic));
-  await db.delete(oidcRefreshTokens).where(eq(oidcRefreshTokens.clientId, oidcClientPublic));
-  await db.delete(oidcDeviceCodes).where(eq(oidcDeviceCodes.clientId, oidcClientPublic));
+  await db.delete(m.oidcAuthCodes).where(eq(m.oidcAuthCodes.clientId, oidcClientPublic));
+  await db.delete(m.oidcRefreshTokens).where(eq(m.oidcRefreshTokens.clientId, oidcClientPublic));
+  await db.delete(m.oidcDeviceCodes).where(eq(m.oidcDeviceCodes.clientId, oidcClientPublic));
 
-  await db.delete(apiKeys).where(eq(apiKeys.clientId, appId));
-  await db.delete(subscriptions).where(eq(subscriptions.clientId, appId));
-  await db.delete(planCapabilityBundles).where(eq(planCapabilityBundles.clientId, appId));
-  await db.delete(plans).where(eq(plans.clientId, appId));
+  await db.delete(m.apiKeys).where(eq(m.apiKeys.clientId, appId));
+  await db.delete(m.subscriptions).where(eq(m.subscriptions.clientId, appId));
+  await db.delete(m.planCapabilityBundles).where(eq(m.planCapabilityBundles.clientId, appId));
+  await db.delete(m.plans).where(eq(m.plans.clientId, appId));
 
-  await db.delete(usageRecords).where(eq(usageRecords.clientId, appId));
-  await db.delete(authAuditLog).where(eq(authAuditLog.clientId, appId));
-  await db.delete(appAllowedDomains).where(eq(appAllowedDomains.appId, appId));
+  await db.delete(m.usageRecords).where(eq(m.usageRecords.clientId, appId));
+  await db.delete(m.authAuditLog).where(eq(m.authAuditLog.clientId, appId));
+  await db.delete(m.appAllowedDomains).where(eq(m.appAllowedDomains.appId, appId));
 
   const appUserRows = await db
-    .select({ id: appUsers.id })
-    .from(appUsers)
-    .where(eq(appUsers.clientId, appId));
+    .select({ id: m.appUsers.id })
+    .from(m.appUsers)
+    .where(eq(m.appUsers.clientId, appId));
   const appUserIds = appUserRows.map((row) => row.id);
   if (appUserIds.length > 0) {
     await db
-      .delete(sessions)
-      .where(inArray(sessions.userId, appUserIds));
+      .delete(m.sessions)
+      .where(inArray(m.sessions.userId, appUserIds));
   }
-  await db.delete(appUsers).where(eq(appUsers.clientId, appId));
-  await db.delete(providerAdmins).where(eq(providerAdmins.clientId, appId));
+  await db.delete(m.appUsers).where(eq(m.appUsers.clientId, appId));
+  await db.delete(m.providerAdmins).where(eq(m.providerAdmins.clientId, appId));
 
   const endUserRows = await db
-    .select({ id: endUsers.id })
-    .from(endUsers)
-    .where(eq(endUsers.appId, appId));
+    .select({ id: m.endUsers.id })
+    .from(m.endUsers)
+    .where(eq(m.endUsers.appId, appId));
   const endUserIds = endUserRows.map((row) => row.id);
 
   if (endUserIds.length > 0) {
     await db
-      .delete(transactions)
-      .where(inArray(transactions.endUserId, endUserIds));
+      .delete(m.transactions)
+      .where(inArray(m.transactions.endUserId, endUserIds));
     await db
-      .delete(streamSessions)
-      .where(inArray(streamSessions.endUserId, endUserIds));
+      .delete(m.streamSessions)
+      .where(inArray(m.streamSessions.endUserId, endUserIds));
   }
 
-  await db.delete(streamSessions).where(eq(streamSessions.appId, appId));
-  await db.delete(transactions).where(eq(transactions.clientId, appId));
-  await db.delete(transactions).where(eq(transactions.appId, appId));
-  await db.delete(endUsers).where(eq(endUsers.appId, appId));
+  await db.delete(m.streamSessions).where(eq(m.streamSessions.appId, appId));
+  await db.delete(m.transactions).where(eq(m.transactions.clientId, appId));
+  await db.delete(m.transactions).where(eq(m.transactions.appId, appId));
+  await db.delete(m.endUsers).where(eq(m.endUsers.appId, appId));
 
-  await db.delete(developerApps).where(eq(developerApps.id, appId));
-  await db.delete(oidcClients).where(eq(oidcClients.id, oidcClientPk));
+  await db.delete(m.developerApps).where(eq(m.developerApps.id, appId));
+  await db.delete(m.oidcClients).where(eq(m.oidcClients.id, oidcClientPk));
   if (appUserIds.length > 0) {
-    await db.delete(users).where(inArray(users.id, appUserIds));
+    await db.delete(m.users).where(inArray(m.users.id, appUserIds));
   }
-  await db.delete(users).where(eq(users.id, ownerId));
+  await db.delete(m.users).where(eq(m.users.id, ownerId));
 }
 
 export function basicAuthHeader(clientId: string, clientSecret: string): string {

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -3,12 +3,14 @@ import type { TestContext } from "node:test";
 import { eq, inArray } from "drizzle-orm";
 
 import { db } from "@/db/index";
-import {
-  appUsers,
-  developerApps,
-  signerConfig,
-  users,
-} from "@/db/schema";
+// Namespace import (not named imports / dynamic import): matches the pattern in
+// `src/db/index.ts` that drizzle uses reliably. On CI we saw named and dynamic
+// forms intermittently return a module with missing bindings from `tsx`'s path
+// alias resolution inside the node --test subprocess, which caused
+// `m.oidcAuthCodes` to be undefined in `cleanupTestApp`'s teardown hook.
+import * as schema from "@/db/schema";
+
+const { appUsers, developerApps, signerConfig, users } = schema;
 import { createAppClient, rotateClientSecret } from "@/lib/oidc/clients";
 import { createSession } from "@/lib/auth";
 
@@ -166,73 +168,84 @@ export async function ensureRunningSigner(): Promise<() => Promise<void>> {
 export async function cleanupTestApp(
   app: SeededDeveloperApp | undefined | null,
 ): Promise<void> {
-  if (!app?.clientId || !app.oidcClientRowId || !app.userId) {
-    return;
+  if (app == null) {
+    throw new Error("cleanupTestApp: app is null or undefined");
   }
-
-  // Dynamic import avoids rare ESM circular-init cases where top-level named
-  // table imports are still undefined when `t.after` teardown runs (seen on CI).
-  const m = await import("@/db/schema");
+  if (typeof app.clientId !== "string" || app.clientId.trim() === "") {
+    throw new Error(
+      "cleanupTestApp: app.clientId must be a non-empty string (seeded developer app id / public client id)",
+    );
+  }
+  if (typeof app.oidcClientRowId !== "string" || app.oidcClientRowId.trim() === "") {
+    throw new Error(
+      "cleanupTestApp: app.oidcClientRowId must be a non-empty string (oidc_clients primary key)",
+    );
+  }
+  if (typeof app.userId !== "string" || app.userId.trim() === "") {
+    throw new Error(
+      "cleanupTestApp: app.userId must be a non-empty string (owner platform user id)",
+    );
+  }
 
   const appId = app.clientId;
   const oidcClientPublic = app.clientId;
   const oidcClientPk = app.oidcClientRowId;
   const ownerId = app.userId;
 
-  await db.delete(m.sessions).where(eq(m.sessions.appId, oidcClientPublic));
+  await db.delete(schema.sessions).where(eq(schema.sessions.appId, oidcClientPublic));
 
-  await db.delete(m.oidcAuthCodes).where(eq(m.oidcAuthCodes.clientId, oidcClientPublic));
-  await db.delete(m.oidcRefreshTokens).where(eq(m.oidcRefreshTokens.clientId, oidcClientPublic));
-  await db.delete(m.oidcDeviceCodes).where(eq(m.oidcDeviceCodes.clientId, oidcClientPublic));
+  await db.delete(schema.oidcAuthCodes).where(eq(schema.oidcAuthCodes.clientId, oidcClientPublic));
+  await db.delete(schema.oidcRefreshTokens).where(eq(schema.oidcRefreshTokens.clientId, oidcClientPublic));
+  await db.delete(schema.oidcDeviceCodes).where(eq(schema.oidcDeviceCodes.clientId, oidcClientPublic));
 
-  await db.delete(m.apiKeys).where(eq(m.apiKeys.clientId, appId));
-  await db.delete(m.subscriptions).where(eq(m.subscriptions.clientId, appId));
-  await db.delete(m.planCapabilityBundles).where(eq(m.planCapabilityBundles.clientId, appId));
-  await db.delete(m.plans).where(eq(m.plans.clientId, appId));
+  await db.delete(schema.apiKeys).where(eq(schema.apiKeys.clientId, appId));
+  await db.delete(schema.subscriptions).where(eq(schema.subscriptions.clientId, appId));
+  await db.delete(schema.planCapabilityBundles).where(eq(schema.planCapabilityBundles.clientId, appId));
+  await db.delete(schema.plans).where(eq(schema.plans.clientId, appId));
 
-  await db.delete(m.usageRecords).where(eq(m.usageRecords.clientId, appId));
-  await db.delete(m.authAuditLog).where(eq(m.authAuditLog.clientId, appId));
-  await db.delete(m.appAllowedDomains).where(eq(m.appAllowedDomains.appId, appId));
+  await db.delete(schema.usageRecords).where(eq(schema.usageRecords.clientId, appId));
+  await db.delete(schema.authAuditLog).where(eq(schema.authAuditLog.clientId, appId));
+  await db.delete(schema.appAllowedDomains).where(eq(schema.appAllowedDomains.appId, appId));
 
   const appUserRows = await db
-    .select({ id: m.appUsers.id })
-    .from(m.appUsers)
-    .where(eq(m.appUsers.clientId, appId));
+    .select({ id: schema.appUsers.id })
+    .from(schema.appUsers)
+    .where(eq(schema.appUsers.clientId, appId));
   const appUserIds = appUserRows.map((row) => row.id);
   if (appUserIds.length > 0) {
     await db
-      .delete(m.sessions)
-      .where(inArray(m.sessions.userId, appUserIds));
+      .delete(schema.sessions)
+      .where(inArray(schema.sessions.userId, appUserIds));
   }
-  await db.delete(m.appUsers).where(eq(m.appUsers.clientId, appId));
-  await db.delete(m.providerAdmins).where(eq(m.providerAdmins.clientId, appId));
+  await db.delete(schema.appUsers).where(eq(schema.appUsers.clientId, appId));
+  await db.delete(schema.providerAdmins).where(eq(schema.providerAdmins.clientId, appId));
 
   const endUserRows = await db
-    .select({ id: m.endUsers.id })
-    .from(m.endUsers)
-    .where(eq(m.endUsers.appId, appId));
+    .select({ id: schema.endUsers.id })
+    .from(schema.endUsers)
+    .where(eq(schema.endUsers.appId, appId));
   const endUserIds = endUserRows.map((row) => row.id);
 
   if (endUserIds.length > 0) {
     await db
-      .delete(m.transactions)
-      .where(inArray(m.transactions.endUserId, endUserIds));
+      .delete(schema.transactions)
+      .where(inArray(schema.transactions.endUserId, endUserIds));
     await db
-      .delete(m.streamSessions)
-      .where(inArray(m.streamSessions.endUserId, endUserIds));
+      .delete(schema.streamSessions)
+      .where(inArray(schema.streamSessions.endUserId, endUserIds));
   }
 
-  await db.delete(m.streamSessions).where(eq(m.streamSessions.appId, appId));
-  await db.delete(m.transactions).where(eq(m.transactions.clientId, appId));
-  await db.delete(m.transactions).where(eq(m.transactions.appId, appId));
-  await db.delete(m.endUsers).where(eq(m.endUsers.appId, appId));
+  await db.delete(schema.streamSessions).where(eq(schema.streamSessions.appId, appId));
+  await db.delete(schema.transactions).where(eq(schema.transactions.clientId, appId));
+  await db.delete(schema.transactions).where(eq(schema.transactions.appId, appId));
+  await db.delete(schema.endUsers).where(eq(schema.endUsers.appId, appId));
 
-  await db.delete(m.developerApps).where(eq(m.developerApps.id, appId));
-  await db.delete(m.oidcClients).where(eq(m.oidcClients.id, oidcClientPk));
+  await db.delete(schema.developerApps).where(eq(schema.developerApps.id, appId));
+  await db.delete(schema.oidcClients).where(eq(schema.oidcClients.id, oidcClientPk));
   if (appUserIds.length > 0) {
-    await db.delete(m.users).where(inArray(m.users.id, appUserIds));
+    await db.delete(schema.users).where(inArray(schema.users.id, appUserIds));
   }
-  await db.delete(m.users).where(eq(m.users.id, ownerId));
+  await db.delete(schema.users).where(eq(schema.users.id, ownerId));
 }
 
 export function basicAuthHeader(clientId: string, clientSecret: string): string {

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -1,16 +1,9 @@
 import { randomUUID } from "node:crypto";
 import type { TestContext } from "node:test";
-import { eq, inArray } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 import { db } from "@/db/index";
-// Namespace import (not named imports / dynamic import): matches the pattern in
-// `src/db/index.ts` that drizzle uses reliably. On CI we saw named and dynamic
-// forms intermittently return a module with missing bindings from `tsx`'s path
-// alias resolution inside the node --test subprocess, which caused
-// `m.oidcAuthCodes` to be undefined in `cleanupTestApp`'s teardown hook.
-import * as schema from "@/db/schema";
-
-const { appUsers, developerApps, signerConfig, users } = schema;
+import { appUsers, developerApps, signerConfig, users } from "@/db/schema";
 import { createAppClient, rotateClientSecret } from "@/lib/oidc/clients";
 import { createSession } from "@/lib/auth";
 
@@ -192,60 +185,76 @@ export async function cleanupTestApp(
   const oidcClientPk = app.oidcClientRowId;
   const ownerId = app.userId;
 
-  await db.delete(schema.sessions).where(eq(schema.sessions.appId, oidcClientPublic));
-
-  await db.delete(schema.oidcAuthCodes).where(eq(schema.oidcAuthCodes.clientId, oidcClientPublic));
-  await db.delete(schema.oidcRefreshTokens).where(eq(schema.oidcRefreshTokens.clientId, oidcClientPublic));
-  await db.delete(schema.oidcDeviceCodes).where(eq(schema.oidcDeviceCodes.clientId, oidcClientPublic));
-
-  await db.delete(schema.apiKeys).where(eq(schema.apiKeys.clientId, appId));
-  await db.delete(schema.subscriptions).where(eq(schema.subscriptions.clientId, appId));
-  await db.delete(schema.planCapabilityBundles).where(eq(schema.planCapabilityBundles.clientId, appId));
-  await db.delete(schema.plans).where(eq(schema.plans.clientId, appId));
-
-  await db.delete(schema.usageRecords).where(eq(schema.usageRecords.clientId, appId));
-  await db.delete(schema.authAuditLog).where(eq(schema.authAuditLog.clientId, appId));
-  await db.delete(schema.appAllowedDomains).where(eq(schema.appAllowedDomains.appId, appId));
-
-  const appUserRows = await db
-    .select({ id: schema.appUsers.id })
-    .from(schema.appUsers)
-    .where(eq(schema.appUsers.clientId, appId));
+  // Use raw SQL (via drizzle's `sql` tag) rather than schema object references.
+  // On the GitHub Actions runner, named and namespace `@/db/schema` imports
+  // have intermittently produced a module with `oidcAuthCodes` (and other
+  // exports) undefined inside `node --test` subprocesses under tsx, which
+  // caused this teardown to crash. Raw DELETEs are immune: they do not touch
+  // the schema module namespace at all, only the `db` client and plain table
+  // names. Order matches the previous FK-safe sequence.
+  const appUserRows = await db.execute<{ id: string }>(
+    sql`SELECT id FROM app_users WHERE client_id = ${appId}`,
+  );
   const appUserIds = appUserRows.map((row) => row.id);
-  if (appUserIds.length > 0) {
-    await db
-      .delete(schema.sessions)
-      .where(inArray(schema.sessions.userId, appUserIds));
-  }
-  await db.delete(schema.appUsers).where(eq(schema.appUsers.clientId, appId));
-  await db.delete(schema.providerAdmins).where(eq(schema.providerAdmins.clientId, appId));
 
-  const endUserRows = await db
-    .select({ id: schema.endUsers.id })
-    .from(schema.endUsers)
-    .where(eq(schema.endUsers.appId, appId));
+  const endUserRows = await db.execute<{ id: string }>(
+    sql`SELECT id FROM end_users WHERE app_id = ${appId}`,
+  );
   const endUserIds = endUserRows.map((row) => row.id);
 
-  if (endUserIds.length > 0) {
-    await db
-      .delete(schema.transactions)
-      .where(inArray(schema.transactions.endUserId, endUserIds));
-    await db
-      .delete(schema.streamSessions)
-      .where(inArray(schema.streamSessions.endUserId, endUserIds));
-  }
-
-  await db.delete(schema.streamSessions).where(eq(schema.streamSessions.appId, appId));
-  await db.delete(schema.transactions).where(eq(schema.transactions.clientId, appId));
-  await db.delete(schema.transactions).where(eq(schema.transactions.appId, appId));
-  await db.delete(schema.endUsers).where(eq(schema.endUsers.appId, appId));
-
-  await db.delete(schema.developerApps).where(eq(schema.developerApps.id, appId));
-  await db.delete(schema.oidcClients).where(eq(schema.oidcClients.id, oidcClientPk));
+  await db.execute(sql`DELETE FROM sessions WHERE app_id = ${oidcClientPublic}`);
   if (appUserIds.length > 0) {
-    await db.delete(schema.users).where(inArray(schema.users.id, appUserIds));
+    await db.execute(
+      sql`DELETE FROM sessions WHERE user_id = ANY(${sql.raw(arrayLiteral(appUserIds))})`,
+    );
   }
-  await db.delete(schema.users).where(eq(schema.users.id, ownerId));
+
+  await db.execute(sql`DELETE FROM oidc_auth_codes WHERE client_id = ${oidcClientPublic}`);
+  await db.execute(sql`DELETE FROM oidc_refresh_tokens WHERE client_id = ${oidcClientPublic}`);
+  await db.execute(sql`DELETE FROM oidc_device_codes WHERE client_id = ${oidcClientPublic}`);
+
+  await db.execute(sql`DELETE FROM api_keys WHERE client_id = ${appId}`);
+  await db.execute(sql`DELETE FROM subscriptions WHERE client_id = ${appId}`);
+  await db.execute(sql`DELETE FROM plan_capability_bundles WHERE client_id = ${appId}`);
+  await db.execute(sql`DELETE FROM plans WHERE client_id = ${appId}`);
+
+  await db.execute(sql`DELETE FROM usage_records WHERE client_id = ${appId}`);
+  await db.execute(sql`DELETE FROM auth_audit_log WHERE client_id = ${appId}`);
+  await db.execute(sql`DELETE FROM app_allowed_domains WHERE app_id = ${appId}`);
+
+  await db.execute(sql`DELETE FROM app_users WHERE client_id = ${appId}`);
+  await db.execute(sql`DELETE FROM provider_admins WHERE client_id = ${appId}`);
+
+  if (endUserIds.length > 0) {
+    const arr = sql.raw(arrayLiteral(endUserIds));
+    await db.execute(sql`DELETE FROM transactions WHERE end_user_id = ANY(${arr})`);
+    await db.execute(sql`DELETE FROM stream_sessions WHERE end_user_id = ANY(${arr})`);
+  }
+
+  await db.execute(sql`DELETE FROM stream_sessions WHERE app_id = ${appId}`);
+  await db.execute(sql`DELETE FROM transactions WHERE client_id = ${appId}`);
+  await db.execute(sql`DELETE FROM transactions WHERE app_id = ${appId}`);
+  await db.execute(sql`DELETE FROM end_users WHERE app_id = ${appId}`);
+
+  await db.execute(sql`DELETE FROM developer_apps WHERE id = ${appId}`);
+  await db.execute(sql`DELETE FROM oidc_clients WHERE id = ${oidcClientPk}`);
+  if (appUserIds.length > 0) {
+    await db.execute(
+      sql`DELETE FROM users WHERE id = ANY(${sql.raw(arrayLiteral(appUserIds))})`,
+    );
+  }
+  await db.execute(sql`DELETE FROM users WHERE id = ${ownerId}`);
+}
+
+/**
+ * Build a Postgres text-array literal (e.g. `ARRAY['a','b']::text[]`) safely
+ * from a list of strings. Ids here come from the caller's test fixture and
+ * previously-inserted rows, never from untrusted input, but we still escape
+ * single quotes defensively to keep the SQL well-formed.
+ */
+function arrayLiteral(ids: string[]): string {
+  const escaped = ids.map((id) => `'${id.replace(/'/g, "''")}'`).join(",");
+  return `ARRAY[${escaped}]::text[]`;
 }
 
 export function basicAuthHeader(clientId: string, clientSecret: string): string {

--- a/src/test-utils/mock-signer.ts
+++ b/src/test-utils/mock-signer.ts
@@ -25,6 +25,7 @@ export function mockSignerFetch(opts?: {
   generateLivePaymentResponse?: unknown;
 }): MockSignerController {
   const signerHost = opts?.signerHost ?? "http://test-signer.invalid";
+  const signerOrigin = new URL(signerHost).origin;
   const original = globalThis.fetch;
 
   const calls: RecordedFetchCall[] = [];
@@ -65,13 +66,21 @@ export function mockSignerFetch(opts?: {
     }
     calls.push({ url, method, body });
 
-    if (!url.startsWith(signerHost)) {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      throw new Error(
+        `mockSignerFetch: invalid URL in test: ${method} ${url}`,
+      );
+    }
+    if (parsedUrl.origin !== signerOrigin) {
       throw new Error(
         `mockSignerFetch: unexpected non-signer fetch in test: ${method} ${url}`,
       );
     }
 
-    const path = "/" + url.slice(signerHost.length).replace(/^\/+/, "");
+    const path = parsedUrl.pathname;
     const failureStatus = failures.get(path);
     if (failureStatus) {
       failures.delete(path);

--- a/src/test-utils/mock-signer.ts
+++ b/src/test-utils/mock-signer.ts
@@ -1,0 +1,96 @@
+/**
+ * Replace globalThis.fetch for the duration of a test so signer proxy routes
+ * never hit the network. Any intercepted URL/body can be inspected via the
+ * returned `calls` array. Non-signer URLs throw so we notice leaks.
+ */
+
+export interface RecordedFetchCall {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+export interface MockSignerController {
+  calls: RecordedFetchCall[];
+  restore: () => void;
+  /** Switch default success responses for a specific path to failure. */
+  failNext: (path: string, status?: number) => void;
+}
+
+export function mockSignerFetch(opts?: {
+  signerHost?: string;
+  signOrchestratorInfoResponse?: unknown;
+  signByocJobResponse?: unknown;
+  discoverOrchestratorsResponse?: unknown;
+  generateLivePaymentResponse?: unknown;
+}): MockSignerController {
+  const signerHost = opts?.signerHost ?? "http://test-signer.invalid";
+  const original = globalThis.fetch;
+
+  const calls: RecordedFetchCall[] = [];
+  const failures = new Map<string, number>();
+
+  const pathDefaults: Record<string, unknown> = {
+    "/sign-orchestrator-info":
+      opts?.signOrchestratorInfoResponse ?? { signedData: "mock-signed" },
+    "/sign-byoc-job":
+      opts?.signByocJobResponse ?? { signedJob: "mock-signed" },
+    "/discover-orchestrators":
+      opts?.discoverOrchestratorsResponse ?? { orchestrators: [] },
+    "/generate-live-payment":
+      opts?.generateLivePaymentResponse ?? { payment: "mock-payment" },
+  };
+
+  const controller: MockSignerController = {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+    failNext: (path, status = 500) => {
+      failures.set(path, status);
+    },
+  };
+
+  const mocked: typeof fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+    let body: unknown = undefined;
+    const rawBody = init?.body;
+    if (typeof rawBody === "string" && rawBody.length > 0) {
+      try {
+        body = JSON.parse(rawBody);
+      } catch {
+        body = rawBody;
+      }
+    }
+    calls.push({ url, method, body });
+
+    if (!url.startsWith(signerHost)) {
+      throw new Error(
+        `mockSignerFetch: unexpected non-signer fetch in test: ${method} ${url}`,
+      );
+    }
+
+    const path = "/" + url.slice(signerHost.length).replace(/^\/+/, "");
+    const failureStatus = failures.get(path);
+    if (failureStatus) {
+      failures.delete(path);
+      return new Response(JSON.stringify({ error: "mock failure" }), {
+        status: failureStatus,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const responseBody =
+      pathDefaults[path] ?? { ok: true, echoed: { path, body } };
+
+    return new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  globalThis.fetch = mocked as typeof fetch;
+
+  return controller;
+}

--- a/src/test-utils/orchestrator-info.ts
+++ b/src/test-utils/orchestrator-info.ts
@@ -1,0 +1,53 @@
+import path from "node:path";
+import protobuf from "protobufjs";
+
+let cachedType: Promise<protobuf.Type> | null = null;
+
+async function getOrchestratorInfoType(): Promise<protobuf.Type> {
+  if (!cachedType) {
+    cachedType = (async () => {
+      const protoPath = path.resolve(process.cwd(), "proto/lp_rpc.proto");
+      const root = await protobuf.load(protoPath);
+      return root.lookupType("net.OrchestratorInfo");
+    })();
+  }
+  return cachedType;
+}
+
+export interface OrchestratorInfoBuildOpts {
+  /** price per unit (wei). Kept within Number.MAX_SAFE_INTEGER so protobufjs encodes deterministically. */
+  pricePerUnit: number;
+  /** pixels per unit (int64). */
+  pixelsPerUnit?: number;
+  /** 20-byte ETH address. Defaults to a fixed orchestrator address. */
+  address?: Buffer;
+  transcoder?: string;
+}
+
+/**
+ * Build a base64-encoded OrchestratorInfo protobuf message suitable for use as
+ * the `Orchestrator` field on a /generate-live-payment request body. The encoded
+ * message is what `decodeOrchestratorInfo` in `src/lib/proto.ts` consumes.
+ */
+export async function buildOrchestratorInfoBase64(
+  opts: OrchestratorInfoBuildOpts,
+): Promise<string> {
+  const type = await getOrchestratorInfoType();
+  const payload = {
+    transcoder: opts.transcoder ?? "https://test-orch.invalid",
+    priceInfo: {
+      pricePerUnit: opts.pricePerUnit,
+      pixelsPerUnit: opts.pixelsPerUnit ?? 1,
+    },
+    address:
+      opts.address ??
+      Buffer.from("000102030405060708090a0b0c0d0e0f10111213", "hex"),
+  };
+  const err = type.verify(payload);
+  if (err) {
+    throw new Error(`invalid OrchestratorInfo payload: ${err}`);
+  }
+  const message = type.create(payload);
+  const encoded = type.encode(message).finish();
+  return Buffer.from(encoded).toString("base64");
+}


### PR DESCRIPTION
### Summary

Adds database-backed integration coverage for signer proxy flows and the Usage API, fixes calling the usage handler from node:test when using Basic auth, ensures the test runner exits cleanly with a pooled Postgres client, and runs the suite in GitHub Actions against Postgres with migrations applied.

### Changes

- **Tests:** High-volume `proxyGenerateLivePayment` + Usage API assertions (totals, `groupBy=user`, filters, invalid dates); signer proxy route tests; usage route tests. Shared helpers under `src/test-utils/` (fixtures, mocked signer `fetch`, DB skip when `DATABASE_URL` is unset).
- **Usage API:** Resolve app via Basic credentials first and only call session-based `getAuthorizedProviderApp` when Basic auth does not match the URL `clientId`, so `getServerSession` / `headers()` are not invoked outside a Next request (fixes failures when tests import the route handler directly).
- **Test runner:** `npm test` adds `--test-force-exit` so Node exits after tests despite open Postgres connections.
- **CI:** New workflow (`.github/workflows/test.yml`) — Postgres 16 service, `npm ci`, `npm run db:prepare`, `npm test` on pushes to `main` and on pull requests.

### How to verify locally

With `DATABASE_URL` set to a migrated Postgres database: `npm run db:prepare && npm test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI workflow to run tests on pushes/PRs with DB service and env setup.
  * Added DB migrations, schema snapshot, and migration journal.
  * Updated test runner to force exit and adjusted ignore rules.

* **New Tests / Test Utilities**
  * Added extensive integration tests for signer proxy and usage endpoints.
  * Added test fixtures, DB guard, mock signer, and orchestrator payload builder utilities.

* **Bug Fixes**
  * Usage API app-resolution now prefers Basic-auth provider lookup when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->