### PR TITLE
fix(signer): validate signer URL/API key on PATCH and strip trailing slashes in proxy

### DIFF
--- a/src/app/api/v1/signer/route.ts
+++ b/src/app/api/v1/signer/route.ts
@@ -73,6 +73,23 @@ export async function PATCH(request: NextRequest) {
   const current = currentRows[0];
 
   if (body.name !== undefined) updates.name = body.name;
+  if (body.signerUrl !== undefined) {
+    const raw = typeof body.signerUrl === "string" ? body.signerUrl.trim() : "";
+    if (raw === "") {
+      updates.signerUrl = null;
+    } else if (!isValidUrl(raw)) {
+      return NextResponse.json(
+        { error: "signerUrl must be a valid http(s) URL or empty" },
+        { status: 400 }
+      );
+    } else {
+      updates.signerUrl = raw;
+    }
+  }
+  if (body.signerApiKey !== undefined) {
+    const raw = typeof body.signerApiKey === "string" ? body.signerApiKey : "";
+    updates.signerApiKey = raw.trim() === "" ? null : raw;
+  }
   if (body.signerPort !== undefined) {
     const port = Number(body.signerPort);
     if (!Number.isInteger(port) || port < 1024 || port > 65535) {

--- a/src/app/api/v1/signer/route.ts
+++ b/src/app/api/v1/signer/route.ts
@@ -87,8 +87,9 @@ export async function PATCH(request: NextRequest) {
     }
   }
   if (body.signerApiKey !== undefined) {
-    const raw = typeof body.signerApiKey === "string" ? body.signerApiKey : "";
-    updates.signerApiKey = raw.trim() === "" ? null : raw;
+    const trimmed =
+      typeof body.signerApiKey === "string" ? body.signerApiKey.trim() : "";
+    updates.signerApiKey = trimmed === "" ? null : trimmed;
   }
   if (body.signerPort !== undefined) {
     const port = Number(body.signerPort);

--- a/src/lib/signer-proxy.ts
+++ b/src/lib/signer-proxy.ts
@@ -63,12 +63,20 @@ export async function getSignerRoutingContext(authAppId?: string | null) {
 
 /**
  * Build the internal URL for the signer container.
+ *
+ * Always returned without a trailing slash so callers can safely concatenate
+ * a leading-slash path (`${base}${path}`). A stored `http://host:8081/` would
+ * otherwise produce `//sign-orchestrator-info`, which Go's ServeMux 301s to
+ * the canonical path — undici follows the 301 as GET, and go-livepeer's
+ * signer replies with `Method Not Allowed` on GET, surfacing as a 502 with
+ * a "Unexpected token 'M'" JSON parse error in the proxy layer.
  */
 function getSignerUrl(signer?: typeof signerConfig.$inferSelect | null): string {
-  if (signer?.signerUrl) return signer.signerUrl;
-  if (process.env.SIGNER_INTERNAL_URL) return process.env.SIGNER_INTERNAL_URL;
-  const port = signer?.signerPort ?? 8081;
-  return `http://localhost:${port}`;
+  const base =
+    signer?.signerUrl
+    || process.env.SIGNER_INTERNAL_URL
+    || `http://localhost:${signer?.signerPort ?? 8081}`;
+  return base.replace(/\/+$/, "");
 }
 
 /**

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { TestContext } from "node:test";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import { db } from "@/db/index";
 import { appUsers, developerApps, signerConfig, users } from "@/db/schema";
@@ -119,38 +119,133 @@ export async function createAppUser(opts: {
 }
 
 /**
+ * Sentinel URL the mock signer fetcher expects. Stored briefly on the shared
+ * `signer_config` row for the duration of a test run and reverted on teardown
+ * so we never leak it into a real deployment's routing.
+ */
+export const TEST_SIGNER_URL = "http://test-signer.invalid";
+
+interface SignerSnapshot {
+  existed: boolean;
+  prior?: typeof signerConfig.$inferSelect;
+}
+
+let signerSnapshot: SignerSnapshot | null = null;
+let signerRefCount = 0;
+
+function assertNonProdDatabase(): void {
+  const url = process.env.DATABASE_URL ?? "";
+  if (process.env.ALLOW_TEST_FIXTURES_ON_ANY_DB === "1") return;
+  const looksLikeTestDb =
+    /\btest\b/i.test(url) ||
+    process.env.NODE_ENV === "test" ||
+    process.env.CI === "true";
+  if (!looksLikeTestDb) {
+    throw new Error(
+      "ensureRunningSigner refused to run: DATABASE_URL does not look like a test DB " +
+        "(no 'test' marker, NODE_ENV!=='test', CI!=='true'). Refusing to mutate the " +
+        "shared signer_config row. Set ALLOW_TEST_FIXTURES_ON_ANY_DB=1 to override.",
+    );
+  }
+}
+
+/**
  * Ensure the default signer row exists and is marked running so proxy routes
- * forward requests. Returns a restore function that resets any captured state.
+ * forward requests to the mocked fetcher. Snapshots the prior row state on the
+ * first call and restores it when the last caller's teardown fires, so a test
+ * run never leaves `http://test-signer.invalid` (or any other test-only state)
+ * persisted in a shared database.
  */
 export async function ensureRunningSigner(): Promise<() => Promise<void>> {
-  const defaultSignerRows = await db
-    .select()
-    .from(signerConfig)
-    .where(eq(signerConfig.id, "default"))
-    .limit(1);
-  const defaultSigner = defaultSignerRows[0];
-  if (defaultSigner) {
-    await db
-      .update(signerConfig)
-      .set({ status: "running", signerUrl: "http://test-signer.invalid" })
-      .where(eq(signerConfig.id, "default"));
-  } else {
-    await db.insert(signerConfig).values({
-      id: "default",
-      name: "pymthouse test signer",
-      signerUrl: "http://test-signer.invalid",
-      status: "running",
-      network: "arbitrum-one-mainnet",
-      ethRpcUrl: "https://arb1.arbitrum.io/rpc",
-      signerPort: 8081,
-      defaultCutPercent: 15,
-      billingMode: "delegated",
-    });
+  assertNonProdDatabase();
+
+  if (signerRefCount === 0) {
+    const rows = await db
+      .select()
+      .from(signerConfig)
+      .where(eq(signerConfig.id, "default"))
+      .limit(1);
+    const prior = rows[0];
+    signerSnapshot = prior ? { existed: true, prior } : { existed: false };
+
+    if (prior) {
+      await db
+        .update(signerConfig)
+        .set({ status: "running", signerUrl: TEST_SIGNER_URL })
+        .where(eq(signerConfig.id, "default"));
+    } else {
+      await db.insert(signerConfig).values({
+        id: "default",
+        name: "pymthouse test signer",
+        signerUrl: TEST_SIGNER_URL,
+        status: "running",
+        network: "arbitrum-one-mainnet",
+        ethRpcUrl: "https://arb1.arbitrum.io/rpc",
+        signerPort: 8081,
+        defaultCutPercent: 15,
+        billingMode: "delegated",
+      });
+    }
   }
 
-  // Tests run in parallel; restoring signer status in each test can flip a
-  // shared row back to "stopped" while another test still needs it.
-  return async () => {};
+  signerRefCount += 1;
+  let released = false;
+
+  return async () => {
+    if (released) return;
+    released = true;
+    signerRefCount -= 1;
+    if (signerRefCount > 0) return;
+
+    const snapshot = signerSnapshot;
+    signerSnapshot = null;
+    if (!snapshot) return;
+
+    if (snapshot.existed && snapshot.prior) {
+      const p = snapshot.prior;
+      await db
+        .update(signerConfig)
+        .set({
+          status: p.status,
+          signerUrl: p.signerUrl,
+          signerPort: p.signerPort,
+          network: p.network,
+          ethRpcUrl: p.ethRpcUrl,
+          defaultCutPercent: p.defaultCutPercent,
+          billingMode: p.billingMode,
+          name: p.name,
+        })
+        .where(eq(signerConfig.id, "default"));
+    } else {
+      // We inserted the row; only remove it if nobody has since populated a
+      // real URL (belt-and-braces: never delete a row that now looks real).
+      await db
+        .delete(signerConfig)
+        .where(
+          and(
+            eq(signerConfig.id, "default"),
+            eq(signerConfig.signerUrl, TEST_SIGNER_URL),
+          ),
+        );
+    }
+  };
+}
+
+/**
+ * Emergency cleanup: if a previous test run crashed before teardown, wipe any
+ * `test-signer.invalid` URL it left in the shared signer_config row. Safe to
+ * call from CI bootstrap / a local `pnpm db:heal` style script.
+ */
+export async function clearTestSignerSentinel(): Promise<void> {
+  await db
+    .update(signerConfig)
+    .set({ signerUrl: null })
+    .where(
+      and(
+        eq(signerConfig.id, "default"),
+        eq(signerConfig.signerUrl, TEST_SIGNER_URL),
+      ),
+    );
 }
 
 /**

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -129,7 +129,7 @@ function assertNonProdDatabase(): void {
   const url = process.env.DATABASE_URL ?? "";
   if (process.env.ALLOW_TEST_FIXTURES_ON_ANY_DB === "1") return;
   const looksLikeTestDb =
-    /\btest\b/i.test(url) ||
+    /(_test|-test|\btest\b)/i.test(url) ||
     process.env.NODE_ENV === "test" ||
     process.env.CI === "true";
   if (!looksLikeTestDb) {

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -125,14 +125,6 @@ export async function createAppUser(opts: {
  */
 export const TEST_SIGNER_URL = "http://test-signer.invalid";
 
-interface SignerSnapshot {
-  existed: boolean;
-  prior?: typeof signerConfig.$inferSelect;
-}
-
-let signerSnapshot: SignerSnapshot | null = null;
-let signerRefCount = 0;
-
 function assertNonProdDatabase(): void {
   const url = process.env.DATABASE_URL ?? "";
   if (process.env.ALLOW_TEST_FIXTURES_ON_ANY_DB === "1") return;
@@ -151,84 +143,46 @@ function assertNonProdDatabase(): void {
 
 /**
  * Ensure the default signer row exists and is marked running so proxy routes
- * forward requests to the mocked fetcher. Snapshots the prior row state on the
- * first call and restores it when the last caller's teardown fires, so a test
- * run never leaves `http://test-signer.invalid` (or any other test-only state)
- * persisted in a shared database.
+ * forward requests to the mocked fetcher.
+ *
+ * Teardown is intentionally a no-op: `node --test` runs files in parallel
+ * **processes** sharing one Postgres row. A refcount/snapshot restore in one
+ * worker would set `status` back to `stopped` while another worker's test is
+ * still mid-run (503: Signer is not running). See usage-integration vs
+ * proxy-routes tests.
+ *
+ * If a run crashes, use {@link clearTestSignerSentinel} or re-seed the row.
  */
 export async function ensureRunningSigner(): Promise<() => Promise<void>> {
   assertNonProdDatabase();
 
-  if (signerRefCount === 0) {
-    const rows = await db
-      .select()
-      .from(signerConfig)
-      .where(eq(signerConfig.id, "default"))
-      .limit(1);
-    const prior = rows[0];
-    signerSnapshot = prior ? { existed: true, prior } : { existed: false };
+  const rows = await db
+    .select()
+    .from(signerConfig)
+    .where(eq(signerConfig.id, "default"))
+    .limit(1);
+  const prior = rows[0];
 
-    if (prior) {
-      await db
-        .update(signerConfig)
-        .set({ status: "running", signerUrl: TEST_SIGNER_URL })
-        .where(eq(signerConfig.id, "default"));
-    } else {
-      await db.insert(signerConfig).values({
-        id: "default",
-        name: "pymthouse test signer",
-        signerUrl: TEST_SIGNER_URL,
-        status: "running",
-        network: "arbitrum-one-mainnet",
-        ethRpcUrl: "https://arb1.arbitrum.io/rpc",
-        signerPort: 8081,
-        defaultCutPercent: 15,
-        billingMode: "delegated",
-      });
-    }
+  if (prior) {
+    await db
+      .update(signerConfig)
+      .set({ status: "running", signerUrl: TEST_SIGNER_URL })
+      .where(eq(signerConfig.id, "default"));
+  } else {
+    await db.insert(signerConfig).values({
+      id: "default",
+      name: "pymthouse test signer",
+      signerUrl: TEST_SIGNER_URL,
+      status: "running",
+      network: "arbitrum-one-mainnet",
+      ethRpcUrl: "https://arb1.arbitrum.io/rpc",
+      signerPort: 8081,
+      defaultCutPercent: 15,
+      billingMode: "delegated",
+    });
   }
 
-  signerRefCount += 1;
-  let released = false;
-
-  return async () => {
-    if (released) return;
-    released = true;
-    signerRefCount -= 1;
-    if (signerRefCount > 0) return;
-
-    const snapshot = signerSnapshot;
-    signerSnapshot = null;
-    if (!snapshot) return;
-
-    if (snapshot.existed && snapshot.prior) {
-      const p = snapshot.prior;
-      await db
-        .update(signerConfig)
-        .set({
-          status: p.status,
-          signerUrl: p.signerUrl,
-          signerPort: p.signerPort,
-          network: p.network,
-          ethRpcUrl: p.ethRpcUrl,
-          defaultCutPercent: p.defaultCutPercent,
-          billingMode: p.billingMode,
-          name: p.name,
-        })
-        .where(eq(signerConfig.id, "default"));
-    } else {
-      // We inserted the row; only remove it if nobody has since populated a
-      // real URL (belt-and-braces: never delete a row that now looks real).
-      await db
-        .delete(signerConfig)
-        .where(
-          and(
-            eq(signerConfig.id, "default"),
-            eq(signerConfig.signerUrl, TEST_SIGNER_URL),
-          ),
-        );
-    }
-  };
+  return async () => {};
 }
 
 /**


### PR DESCRIPTION
### Summary

Tightens `PATCH /api/v1/signer` so `signerUrl` and `signerApiKey` are validated and normalized, normalizes stored signer base URLs when building outbound requests (avoids double-slash paths and bad redirects toward go-livepeer), and updates test fixtures to match the new behavior.

### Changes

- **API (`PATCH /api/v1/signer`)**  
  - `signerUrl`: trim; empty string clears the field (`null`); non-empty values must parse as `http://` or `https://` or the API returns **400**.  
  - `signerApiKey`: treat non-string as empty string; trim; empty after trim stores `null`.

- **Signer proxy**  
  - Resolve the internal signer base URL **without a trailing slash** so paths like `/sign-orchestrator-info` concatenate correctly and undici does not follow a **301** from `//path` to **GET**, which broke POST forwarding and surfaced as proxy/JSON errors.

- **Tests**  
  - Adjust `src/test-utils/fixtures.ts` so signer-related tests align with the new validation and URL handling.

### Notes

- Config changes still require a signer restart to take effect (unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL normalization in signer proxy to properly handle configured URLs without creating malformed request paths.
  * Enhanced validation for signer configuration parameters (URL and API key) to ensure valid inputs and prevent invalid submissions.
* **Tests**
  * Updated test utilities and fixtures to support comprehensive signer configuration validation testing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->