### PR TITLE
feat(apps): update token endpoint auth method to client_secret_post

### DIFF
--- a/src/components/apps/AppSettingsPanel.tsx
+++ b/src/components/apps/AppSettingsPanel.tsx
@@ -94,6 +94,7 @@ export default function AppSettingsPanel({ data }: Props) {
       const body = await res.json();
       if (!res.ok) throw new Error(body.error || "Failed to rotate secret");
       setSecret(body.clientSecret);
+      setTokenEndpointAuthMethod("client_secret_post");
       setMessage("Client secret rotated");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -342,9 +342,10 @@ export default function AppSettingsScreen({
           domains={domains}
           onDomainsChange={setDomains}
           hasSecret={appState.hasSecret}
-          onSecretGenerated={() =>
-            setAppState((s) => ({ ...s, hasSecret: true }))
-          }
+          onSecretGenerated={() => {
+            setAppState((s) => ({ ...s, hasSecret: true }));
+            updateFormData({ tokenEndpointAuthMethod: "client_secret_post" });
+          }}
           readOnly={!canEdit}
         />
       </section>

--- a/src/components/apps/AppWizard.tsx
+++ b/src/components/apps/AppWizard.tsx
@@ -231,9 +231,10 @@ export default function AppWizard({ initialData, initialState, initialDomains }:
             domains={domains}
             onDomainsChange={setDomains}
             hasSecret={appState.hasSecret}
-            onSecretGenerated={() =>
-              setAppState((s) => ({ ...s, hasSecret: true }))
-            }
+            onSecretGenerated={() => {
+              setAppState((s) => ({ ...s, hasSecret: true }));
+              updateFormData({ tokenEndpointAuthMethod: "client_secret_post" });
+            }}
           />
         )}
       </div>

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -448,8 +448,7 @@ export default function TestingStep({
               </button>
             </div>
             <p className="text-xs text-amber-400/80">
-              Store this secret securely. It will not be shown again. Save the app using
-              the button at the bottom of the page before using this new secret.
+              Store this secret securely. It will not be shown again.
             </p>
           </div>
         ) : (


### PR DESCRIPTION
- Added logic to set the token endpoint authentication method to "client_secret_post" upon secret generation in AppSettingsPanel, AppSettingsScreen, and AppWizard components.
- Updated the message in TestingStep to clarify the importance of securely storing the secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed credential rotation to properly configure authentication method alongside secret generation.

* **Documentation**
  * Streamlined guidance text when generating secrets to focus on the essential security instruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->